### PR TITLE
Fix bug where default style.css wasn't copied

### DIFF
--- a/src/quickblog/api.clj
+++ b/src/quickblog/api.clj
@@ -273,7 +273,7 @@
                          posts-file))
         (println "No posts found; run `bb new` to create one"))
       (System/exit 1))
-    (lib/ensure-resource (fs/file templates-dir "style.css"))
+    (lib/ensure-template opts "style.css")
     (ensure-favicon-assets opts)
     (when (fs/exists? assets-dir)
       (lib/copy-tree-modified assets-dir assets-out-dir))


### PR DESCRIPTION
Please answer the following questions and leave the below in as part of your PR.

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code): #19 

- [x] I have updated the [CHANGELOG.md](https://github.com/babashka/babashka/blob/master/CHANGELOG.md) file with a description of the addressed issue: I didn't feel this was necessary since it was a minor bugfix, but happy to do so if you prefer.
