### PR TITLE
Add `:bbin/bin` to `bb.edn`

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -5,6 +5,8 @@
         }
  :paths ["."]
 
+ :bbin/bin {quickblog {:ns-default quickblog.api}}
+
  :tasks
 
  {:init (def opts (merge {:blog-title "REPL adventures"


### PR DESCRIPTION
Please answer the following questions and leave the below in as part of your PR.

- [ ] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).
- [ ] I have updated the [CHANGELOG.md](https://github.com/babashka/babashka/blob/master/CHANGELOG.md) file with a description of the addressed issue.

## Overview

Requires the latest version of `bbin`.

```
$ bbin install io.github.borkdude/quickblog --git/sha 7de4082d91fe5c88ec34134b0fcc7b743f6960d5
{:lib io.github.borkdude/quickblog,
 :coords
 {:git/url "https://github.com/borkdude/quickblog",
  :git/sha "7de4082d91fe5c88ec34134b0fcc7b743f6960d5"}}
Cloning: https://github.com/borkdude/quickblog
Checking out: https://github.com/borkdude/quickblog at 7de4082d91fe5c88ec34134b0fcc7b743f6960d5
Cloning: https://github.com/babashka/pods
Checking out: https://github.com/babashka/pods at 93081b75e66fb4c4d161f89e714c6b9e8d55c8d5

$ quickblog
Usage: quickblog <command>

  quickblog serve              Runs file-server on `port`.
  quickblog new                Creates new `file` in posts dir.
  quickblog quickblog          Alias for `render`
  quickblog migrate            Migrates from `posts.edn` to post-local metadata
  quickblog render             Renders posts declared in `posts.edn` to `out-dir`.
  quickblog refresh-templates  Updates to latest default templates
  quickblog watch              Watches `posts.edn`, `posts` and `templates` for changes. Runs file
```