### PR TITLE
Add command line interface

### DIFF
--- a/API.md
+++ b/API.md
@@ -4,15 +4,33 @@
 
 
 
-## `new`
+## `clean`
 ``` clojure
 
-(new {:keys [file title posts-dir], :or {posts-dir (:posts-dir default-opts)}, :as opts})
+(clean opts)
 ```
 
 
-Creates new entry in `posts.edn` and creates `file` in `posts` dir.
-<br><sub>[source](https://github.com/borkdude/quickblog/blob/main/src/quickblog/api.clj#L226-L245)</sub>
+Removes cache and output directories
+<br><sub>[source](https://github.com/borkdude/quickblog/blob/main/src/quickblog/api.clj#L493-L499)</sub>
+## `migrate`
+``` clojure
+
+(migrate opts)
+```
+
+
+Migrates from `posts.edn` to post-local metadata
+<br><sub>[source](https://github.com/borkdude/quickblog/blob/main/src/quickblog/api.clj#L501-L512)</sub>
+## `new`
+``` clojure
+
+(new opts)
+```
+
+
+Creates new `file` in posts dir.
+<br><sub>[source](https://github.com/borkdude/quickblog/blob/main/src/quickblog/api.clj#L466-L491)</sub>
 ## `quickblog`
 ``` clojure
 
@@ -21,40 +39,71 @@ Creates new entry in `posts.edn` and creates `file` in `posts` dir.
 
 
 Alias for `render`
-<br><sub>[source](https://github.com/borkdude/quickblog/blob/main/src/quickblog/api.clj#L217-L220)</sub>
+<br><sub>[source](https://github.com/borkdude/quickblog/blob/main/src/quickblog/api.clj#L457-L460)</sub>
+## `refresh-templates`
+``` clojure
+
+(refresh-templates opts)
+```
+
+
+Updates to latest default templates
+<br><sub>[source](https://github.com/borkdude/quickblog/blob/main/src/quickblog/api.clj#L514-L517)</sub>
 ## `render`
 ``` clojure
 
-(render
- {:keys [blog-title cache-dir out-dir posts-dir discuss-link],
-  :or {cache-dir (:cache-dir default-opts), out-dir (:out-dir default-opts), posts-dir (:posts-dir default-opts)},
-  :as opts})
+(render opts)
 ```
 
 
 Renders posts declared in `posts.edn` to `out-dir`.
-<br><sub>[source](https://github.com/borkdude/quickblog/blob/main/src/quickblog/api.clj#L174-L214)</sub>
+<br><sub>[source](https://github.com/borkdude/quickblog/blob/main/src/quickblog/api.clj#L421-L455)</sub>
 ## `serve`
 ``` clojure
 
-(serve {:keys [port out-dir], :or {port 1888, out-dir (:out-dir default-opts)}})
+(serve opts)
 ```
 
 
 Runs file-server on `port`.
-<br><sub>[source](https://github.com/borkdude/quickblog/blob/main/src/quickblog/api.clj#L247-L254)</sub>
+<br><sub>[source](https://github.com/borkdude/quickblog/blob/main/src/quickblog/api.clj#L519-L532)</sub>
 ## `watch`
 ``` clojure
 
-(watch
- {:keys [posts-dir watch-script],
-  :or
-  {posts-dir (:posts-dir default-opts),
-   watch-script "<script type=\"text/javascript\" src=\"https://livejs.com/live.js\"></script>"},
-  :as opts})
+(watch opts)
 ```
 
 
-Watches `posts.edn`, `posts` and `templates` for changes. Runs file
-  server using `serve`.
-<br><sub>[source](https://github.com/borkdude/quickblog/blob/main/src/quickblog/api.clj#L256-L285)</sub>
+Watches posts, templates, and assets for changes. Runs file server using
+  `serve`.
+<br><sub>[source](https://github.com/borkdude/quickblog/blob/main/src/quickblog/api.clj#L536-L601)</sub>
+# quickblog.cli 
+
+
+
+
+
+## `-main`
+``` clojure
+
+(-main & args)
+```
+
+<sub>[source](https://github.com/borkdude/quickblog/blob/main/src/quickblog/cli.clj#L143-L144)</sub>
+## `dispatch`
+``` clojure
+
+(dispatch)
+(dispatch default-opts & args)
+```
+
+<sub>[source](https://github.com/borkdude/quickblog/blob/main/src/quickblog/cli.clj#L127-L133)</sub>
+## `run`
+``` clojure
+
+(run default-opts)
+```
+
+
+Meant to be called using `clj -M:quickblog`; see Quickstart > Clojure in README
+<br><sub>[source](https://github.com/borkdude/quickblog/blob/main/src/quickblog/cli.clj#L135-L141)</sub>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased:
 
+- Add command line interface
 - Watch assets dir for changes in watch mode
 - Added `refresh-templates` task to update to latest templates
 - Social sharing (preview for Facebook, Twitter, LinkedIn, etc.)

--- a/README.md
+++ b/README.md
@@ -12,31 +12,33 @@ Includes hot-reload. See it in action [here](https://twitter.com/borkdude/status
 
 ### Babashka
 
-Copy the config from `bb.edn` in this project to your local `bb.edn`. Then run `bb tasks`:
+quickblog is meant to be used as a library from your Babashka project. The
+easiest way to use it is to add a task to your project's `bb.edn`.
 
-```
-$ bb tasks
-The following tasks are available:
+This example assumes a basic `bb.edn` like this:
 
-new       Create new blog article
-delete    Delete blog article
-quickblog Render blog
-watch     Watch posts and templates and render file changes
-publish   Publish blog
-clean     Remove cache and output directories
-migrate   Migrate away from `posts.edn` to metadata in post files
+``` clojure
+{:deps {io.github.borkdude/quickblog
+        #_"You use the newest SHA here:"
+        {:git/sha "389833f393e04d4176ef3eaa5047fa307a5ff2e8"}}
+ :tasks
+ {:requires ([quickblog.cli :as cli])
+  :init (def opts {:blog-title "REPL adventures"
+                   :blog-description "A blog about blogging quickly"})
+  quickblog {:doc "Start blogging quickly! Run `bb quickblog help` for details."
+             :task (cli/dispatch opts)}}}
 ```
 
 To create a new blog post:
 
 ``` clojure
-$ bb new :file "test.md" :title "Test"
+$ bb quickblog new --file "test.md" --title "Test"
 ```
 
-To watch:
+To start an HTTP server and re-render on changes to files:
 
 ```
-$ bb watch
+$ bb quickblog watch
 ```
 
 ### Clojure
@@ -45,25 +47,26 @@ Quickblog can be used in Clojure with the exact same API as the bb tasks.
 Default options can be configured in `:exec-args`.
 
 ``` clojure
-:quickblog {:deps {io.github.borkdude/quickblog
-                   {:git/sha "b69c11f4292702f78a8ac0a9f32379603bebf2af"}
-                   org.babashka/cli {:mvn/version "0.3.31"}}
-            :main-opts ["-m" "babashka.cli.exec" "quickblog.api"]
-            :exec-args {:blog-title "REPL adventures"
-                        :out-dir "public"
-                        :blog-root "https://blog.michielborkent.nl/"}}
+:quickblog
+{:deps {io.github.borkdude/quickblog
+        #_"You use the newest SHA here:"
+        {:git/sha "389833f393e04d4176ef3eaa5047fa307a5ff2e8"}
+        org.babashka/cli {:mvn/version "0.3.35"}}
+ :main-opts ["-m" "babashka.cli.exec" "quickblog.cli" "run"]
+ :exec-args {:blog-title "REPL adventures"
+             :blog-description "A blog about blogging quickly"}}
 ```
 
 After configuring this, you can call:
 
 ```
-clj -M:quickblog new :file "test.md" :title "Test"
+$ clj -M:quickblog new --file "test.md" --title "Test"
 ```
 
 To watch:
 
 ```
-clj -M:quickblog watch
+$ clj -M:quickblog watch
 ```
 
 etc.
@@ -73,7 +76,8 @@ etc.
 ### favicon
 
 **NOTE:** when enabling or disabling a favicon, you must do a full re-render of
-your site by running `bb clean` and then your `bb render` command.
+your site by running `bb quickblog clean` and then your `bb quickblog render`
+command.
 
 To enable a [favicon](https://en.wikipedia.org/wiki/Favicon), add `:favicon
 true` to your quickblog opts (or use `--favicon true` on the command line).
@@ -181,9 +185,8 @@ templates to suit your needs and preferences.
 
 The default templates are occasionally modified to support new features. When
 this happens, you won't be able to use the new feature without making the same
-modifications to your local templates. The easiest way to do this is to copy the
-`refresh-templates` task from quickblog's `bb.edn` into your own `bb.edn` and
-run `bb refresh-templates`.
+modifications to your local templates. The easiest way to do this is to run `bb
+quickblog refresh-templates`.
 
 ## Breaking changes
 
@@ -191,7 +194,7 @@ run `bb refresh-templates`.
 
 quickblog now keeps metadata for each blog post in the post file itself. It used
 to use a `posts.edn` file for this purpose. If you are upgrading from a version
-that used `posts.edn`, you should run `bb migrate` and then remove the
+that used `posts.edn`, you should run `bb quickblog migrate` and then remove the
 `posts.edn` file.
 
 ## Improvements

--- a/bb.edn
+++ b/bb.edn
@@ -1,49 +1,46 @@
-{:deps {org.babashka/cli {:mvn/version "0.3.35"}
-        io.github.borkdude/quickblog {:local/root "."}
-        #_"You use the newest SHA here:"
-        #_{:git/sha "b69c11f4292702f78a8ac0a9f32379603bebf2af"}
-        }
+{:deps {io.github.borkdude/quickblog {:local/root "."}}
  :paths ["."]
 
  :bbin/bin {quickblog {:ns-default quickblog.api}}
 
  :tasks
+ {:requires ([babashka.fs :as fs]
+             [quickblog.cli :as cli])
+  :init (do
+          (def opts {:blog-title "REPL adventures"
+                     :blog-description "A blog about blogging quickly"
+                     :blog-root "http://localhost:1888"
+                     :about-link "https://github.com/borkdude/quickblog"
+                     :twitter-handle "quickblog"
+                     :out-dir "public"})
+          (defn- run-command [cmd-name opts]
+            (apply cli/dispatch opts cmd-name *command-line-args*)))
 
- {:init (def opts (merge {:blog-title "REPL adventures"
-                          :blog-description "A blog about blogging quickly"
-                          :blog-root "http://localhost:1888"
-                          :about-link "https://github.com/borkdude/quickblog"
-                          :twitter-handle "quickblog"
-                          :out-dir "public"}
-                         (cli/parse-opts *command-line-args*)))
-
-  :requires ([babashka.fs :as fs]
-             [quickblog.api :as qb]
-             [babashka.cli :as cli])
+  quickblog {:doc "Start blogging quickly! Run `bb quickblog help` for details."
+             :task (cli/dispatch opts)}
 
   new {:doc "Create new blog article"
-       :task (qb/new opts)}
+       :task (run-command "new" opts)}
 
   migrate {:doc "Migrate away from posts.edn to metadata in post files"
-           :task (qb/migrate opts)}
+           :task (run-command "migrate" opts)}
 
   refresh-templates
   {:doc "Update to latest templates. NOTE: this is a destructive operation, as it will overwrite any templates you have in your `:templates-dir`. You should ensure that your templates are backed up or under revision control before running this command!"
-   :task (qb/refresh-templates opts)}
+   :task (run-command "refresh-templates" opts)}
 
   render {:doc "Render blog"
-          :task (qb/render opts)}
+          :task (run-command "render" opts)}
 
   watch  {:doc "Watch posts and templates and render file changes"
-          :task (qb/watch opts)}
+          :task (run-command "watch" opts)}
+
+  clean {:doc "Remove cache and output directories"
+         :task (run-command "clean" opts)}
 
   publish {:doc "Publish blog"
            :depends [render]
            :task (shell "rsync -a --delete public/ user@yourdomain:~/blog")}
-
-  clean {:doc "Remove cache and output directories"
-         :task (do (fs/delete-tree ".work")
-                   (fs/delete-tree "public"))}
 
   test {:doc "Run tests"
         :task (apply clojure "-M:test" *command-line-args*)}

--- a/bb.edn
+++ b/bb.edn
@@ -1,4 +1,4 @@
-{:deps {org.babashka/cli {:mvn/version "0.3.31"}
+{:deps {org.babashka/cli {:mvn/version "0.3.35"}
         io.github.borkdude/quickblog {:local/root "."}
         #_"You use the newest SHA here:"
         #_{:git/sha "b69c11f4292702f78a8ac0a9f32379603bebf2af"}

--- a/bb.edn
+++ b/bb.edn
@@ -9,10 +9,8 @@
   :init (do
           (def opts {:blog-title "REPL adventures"
                      :blog-description "A blog about blogging quickly"
-                     :blog-root "http://localhost:1888"
                      :about-link "https://github.com/borkdude/quickblog"
-                     :twitter-handle "quickblog"
-                     :out-dir "public"})
+                     :twitter-handle "quickblog"})
           (defn- run-command [cmd-name opts]
             (apply cli/dispatch opts cmd-name *command-line-args*)))
 

--- a/deps.edn
+++ b/deps.edn
@@ -6,6 +6,7 @@
         org.clojure/data.xml {:mvn/version "0.2.0-alpha6"}
         selmer/selmer {:mvn/version "1.12.53"}
         markdown-clj/markdown-clj {:mvn/version "1.11.2"}
+        org.babashka/cli {:mvn/version "0.3.35"}
         org.babashka/http-server {:mvn/version "0.1.11"}
         babashka/babashka.pods {:git/url "https://github.com/babashka/pods"
                                 :git/sha "93081b75e66fb4c4d161f89e714c6b9e8d55c8d5"}}

--- a/deps.edn
+++ b/deps.edn
@@ -10,10 +10,19 @@
         org.babashka/http-server {:mvn/version "0.1.11"}
         babashka/babashka.pods {:git/url "https://github.com/babashka/pods"
                                 :git/sha "93081b75e66fb4c4d161f89e714c6b9e8d55c8d5"}}
- :quickblog {:deps {org.babashka/cli {:mvn/version "0.3.31"}}
-             :main-opts ["-m" "babashka.cli.exec" "quickblog.api"]}
  :aliases
- {:test
+ {:quickblog
+  {:deps {io.github.borkdude/quickblog
+          {:local/root "."}
+          org.babashka/cli {:mvn/version "0.3.35"}}
+   :main-opts ["-m" "babashka.cli.exec" "quickblog.cli" "run"]
+   :exec-args {:blog-title "REPL adventures"
+               :blog-description "A blog about blogging quickly"
+               :blog-root "http://localhost:1888"
+               :about-link "https://github.com/borkdude/quickblog"
+               :twitter-handle "quickblog"
+               :out-dir "public"}}
+  :test
   {:extra-paths ["test"]
    :extra-deps {io.github.cognitect-labs/test-runner
                 {:git/tag "v0.5.1" :git/sha "dfb30dd"}}

--- a/deps.edn
+++ b/deps.edn
@@ -18,10 +18,8 @@
    :main-opts ["-m" "babashka.cli.exec" "quickblog.cli" "run"]
    :exec-args {:blog-title "REPL adventures"
                :blog-description "A blog about blogging quickly"
-               :blog-root "http://localhost:1888"
                :about-link "https://github.com/borkdude/quickblog"
-               :twitter-handle "quickblog"
-               :out-dir "public"}}
+               :twitter-handle "quickblog"}}
   :test
   {:extra-paths ["test"]
    :extra-deps {io.github.cognitect-labs/test-runner

--- a/quickdoc.edn
+++ b/quickdoc.edn
@@ -1,4 +1,4 @@
-{:pods {clj-kondo/clj-kondo {:version "2022.02.09"}}
+{:pods {clj-kondo/clj-kondo {:version "2022.05.31"}}
  :deps {io.github.borkdude/quickdoc {:git/sha "a8068f1c8b13e09a2966804213fc41dd813de18e"}}
 
  :tasks

--- a/src/quickblog/api.clj
+++ b/src/quickblog/api.clj
@@ -1,4 +1,162 @@
 (ns quickblog.api
+  {:org.babashka/cli
+   {:spec
+    {
+     ;; Blog metadata
+     :blog-title
+     {:desc "Title of the blog"
+      :ref "<title>"
+      :default "quickblog"
+      :require true
+      :group :blog-metadata}
+
+     :blog-author
+     {:desc "Author's name"
+      :ref "<name>"
+      :default "Quick Blogger"
+      :require true
+      :group :blog-metadata}
+
+     :blog-description
+     {:desc "Blog description for subtitle and RSS feeds"
+      :ref "<text>"
+      :default "A blog about blogging quickly"
+      :require true
+      :group :blog-metadata}
+
+     :blog-root
+     {:desc "Base URL of the blog"
+      :ref "<url>"
+      :default "https://github.com/borkdude/quickblog"
+      :require true
+      :group :blog-metadata}
+
+     ;; Optional metadata
+     :about-link
+     {:desc "Link to about the author page"
+      :ref "<url>"
+      :group :optional-metadata}
+
+     :discuss-link
+     {:desc "Link to discussion forum for posts"
+      :ref "<url>"
+      :group :optional-metadata}
+
+     :twitter-handle
+     {:desc "Author's Twitter handle"
+      :ref "<handle>"
+      :group :optional-metadata}
+
+     ;; Post config
+     :default-metadata
+     {:desc "Default metadata to add to posts"
+      :default {}
+      :group :post-config}
+
+     :num-index-posts
+     {:desc "Number of most recent posts to show on the index page"
+      :ref "<num>"
+      :default 3
+      :group :post-config}
+
+     :posts-file
+     {:desc "File containing deprecated post metadata (used only for `migrate`)"
+      :ref "<file>"
+      :default "posts.edn"
+      :group :post-config}
+
+     ;; Input directories
+     :assets-dir
+     {:desc "Directory to copy assets (images, etc.) from"
+      :ref "<dir>"
+      :default "assets"
+      :require true
+      :group :input-directories}
+
+     :posts-dir
+     {:desc "Directory to read posts from"
+      :ref "<dir>"
+      :default "posts"
+      :require true
+      :group :input-directories}
+
+     :templates-dir
+     {:desc "Directory to read templates from; see Templates section in README"
+      :ref "<dir>"
+      :default "templates"
+      :require true
+      :group :input-directories}
+
+     ;; Output directories
+     :out-dir
+     {:desc "Base directory for outputting static site"
+      :ref "<dir>"
+      :default "public"
+      :require true
+      :group :output-directories}
+
+     :assets-out-dir
+     {:desc "Directory to write assets to (relative to :out-dir)"
+      :ref "<dir>"
+      :default "assets"
+      :require true
+      :group :output-directories}
+
+     :tags-dir
+     {:desc "Directory to write tags to (relative to :out-dir)"
+      :ref "<dir>"
+      :default "tags"
+      :require true
+      :group :output-directories}
+
+     ;; Caching
+     :force-render
+     {:desc "If true, pages will be re-rendered regardless of cache status"
+      :default false
+      :group :caching}
+
+     :cache-dir
+     {:desc "Directory to use for caching"
+      :ref "<dir>"
+      :default ".work"
+      :require true
+      :group :caching}
+
+     :rendering-system-files
+     {:desc "Files involved in rendering pages (only set if you know what you're doing!)"
+      :ref "<file1> <file2>..."
+      :default ["bb.edn" "deps.edn"]
+      :coerce []
+      :require true
+      :group :caching}
+
+     ;; Social sharing
+     :blog-image
+     {:desc "Blog thumbnail image URL; see Features > Social sharing in README"
+      :ref "<url>"
+      :group :social-sharing}
+
+     ;; Favicon
+     :favicon
+     {:desc "If true, favicon will be added to all pages"
+      :default false
+      :group :favicon}
+
+     :favicon-dir
+     {:desc "Directory to read favicon assets from"
+      :ref "<dir>"
+      :default "assets/favicon"
+      :group :favicon}
+
+     :favicon-out-dir
+     {:desc "Directory to write favicon assets to (relative to :out-dir)"
+      :ref "<dir>"
+      :default "assets/favicon"
+      :group :favicon}
+
+     ;; Command-specific opts
+
+     }}}
   (:require
    [babashka.fs :as fs]
    [clojure.data.xml :as xml]
@@ -293,6 +451,17 @@
 
 (defn new
   "Creates new `file` in posts dir."
+  {:org.babashka/cli
+   {:spec
+    {:file
+     {:desc "Filename of post (relative to posts-dir)"
+      :ref "<filename>"
+      :require true}
+
+     :title
+     {:desc "Title of post"
+      :ref "<title>"
+      :require true}}}}
   [{:keys [file title help
            posts-dir]
     :as opts}]
@@ -341,6 +510,12 @@
 
 (defn serve
   "Runs file-server on `port`."
+  {:org.babashka/cli
+   {:spec
+    {:port
+     {:desc "Port for HTTP server to listen on"
+      :ref "<port>"
+      :default 1888}}}}
   [{:keys [port out-dir] :as opts}]
   (let [serve (requiring-resolve 'babashka.http-server/serve)]
     (serve {:port port
@@ -351,6 +526,12 @@
 (defn watch
   "Watches posts, templates, and assets for changes. Runs file server using
   `serve`."
+  {:org.babashka/cli
+   {:spec
+    {:port
+     {:desc "Port for HTTP server to listen on"
+      :ref "<port>"
+      :default 1888}}}}
   [opts]
   (let [{:keys [assets-dir assets-out-dir posts-dir templates-dir]
          :as opts}

--- a/src/quickblog/cli.clj
+++ b/src/quickblog/cli.clj
@@ -83,8 +83,8 @@ Options:
            (case cause
              :require
              (println
-              (format "Missing required argument %s:\n%s"
-                      option
+              (format "Missing required argument --%s:\n%s"
+                      (name option)
                       (cli/format-opts {:spec cmd-opts})))
              (println msg))
            (System/exit 1))

--- a/src/quickblog/cli.clj
+++ b/src/quickblog/cli.clj
@@ -311,5 +311,13 @@ Options:
                  (or args
                      (seq *command-line-args*)))))
 
+(defn run
+  "Meant to be called using `clj -M:quickblog`; see Quickstart > Clojure in README"
+  [default-opts]
+  ;; *command-line-args* will start with `(quickblog.cli run ...)`, so we need to
+  ;; get rid of the first two items to get at what we care about
+  (let [args (drop 2 *command-line-args*)]
+    (apply dispatch default-opts args)))
+
 (defn -main [& args]
   (apply dispatch {} args))

--- a/src/quickblog/cli.clj
+++ b/src/quickblog/cli.clj
@@ -83,8 +83,9 @@ Options:
            (case cause
              :require
              (println
-              (format "Missing required argument:\n%s"
-                      (cli/format-opts {:spec (select-keys global-specs [option])})))
+              (format "Missing required argument %s:\n%s"
+                      option
+                      (cli/format-opts {:spec cmd-opts})))
              (println msg))
            (System/exit 1))
          (throw (ex-info msg data))))

--- a/src/quickblog/cli.clj
+++ b/src/quickblog/cli.clj
@@ -7,179 +7,8 @@
 
 (def ^:private main-cmd-name "quickblog")
 
-(def ^:private specs
-  {
-   ;; Blog metadata
-   :blog-title
-   {:desc "Title of the blog"
-    :ref "<title>"
-    :default "quickblog"
-    :require true
-    :group :blog-metadata}
-
-   :blog-author
-   {:desc "Author's name"
-    :ref "<name>"
-    :default "Quick Blogger"
-    :require true
-    :group :blog-metadata}
-
-   :blog-description
-   {:desc "Blog description for subtitle and RSS feeds"
-    :ref "<text>"
-    :default "A blog about blogging quickly"
-    :require true
-    :group :blog-metadata}
-
-   :blog-root
-   {:desc "Base URL of the blog"
-    :ref "<url>"
-    :default "https://github.com/borkdude/quickblog"
-    :require true
-    :group :blog-metadata}
-
-   ;; Optional metadata
-   :about-link
-   {:desc "Link to about the author page"
-    :ref "<url>"
-    :group :optional-metadata}
-
-   :discuss-link
-   {:desc "Link to discussion forum for posts"
-    :ref "<url>"
-    :group :optional-metadata}
-
-   :twitter-handle
-   {:desc "Author's Twitter handle"
-    :ref "<handle>"
-    :group :optional-metadata}
-
-   ;; Post config
-   :default-metadata
-   {:desc "Default metadata to add to posts"
-    :default {}
-    :group :post-config}
-
-   :num-index-posts
-   {:desc "Number of most recent posts to show on the index page"
-    :ref "<num>"
-    :default 3
-    :group :post-config}
-
-   :posts-file
-   {:desc "File containing deprecated post metadata (used only for `migrate`)"
-    :ref "<file>"
-    :default "posts.edn"
-    :group :post-config}
-
-   ;; Input directories
-   :assets-dir
-   {:desc "Directory to copy assets (images, etc.) from"
-    :default "assets"
-    :require true
-    :group :input-directories}
-
-   :posts-dir
-   {:desc "Directory to read posts from"
-    :ref "<dir>"
-    :default "posts"
-    :require true
-    :group :input-directories}
-
-   :templates-dir
-   {:desc "Directory to read templates from; see Templates section in README"
-    :default "templates"
-    :require true
-    :group :input-directories}
-
-   ;; Output directories
-   :out-dir
-   {:desc "Base directory for outputting static site"
-    :ref "<dir>"
-    :default "public"
-    :require true
-    :group :output-directories}
-
-   :assets-out-dir
-   {:desc "Directory to write assets to (relative to :out-dir)"
-    :ref "<dir>"
-    :default "assets"
-    :require true
-    :group :output-directories}
-
-   :tags-dir
-   {:desc "Directory to write tags to (relative to :out-dir)"
-    :default "tags"
-    :require true
-    :group :output-directories}
-
-   ;; Caching
-   :force-render
-   {:desc "If true, pages will be re-rendered regardless of cache status"
-    :default false
-    :group :caching}
-
-   :cache-dir
-   {:desc "Directory to use for caching"
-    :ref "<dir>"
-    :default ".work"
-    :require true
-    :group :caching}
-
-   :rendering-system-files
-   {:desc "Files involved in rendering pages (only set if you know what you're doing!)"
-    :ref "<file1> <file2>..."
-    :default ["bb.edn" "deps.edn"]
-    :coerce []
-    :require true
-    :group :caching}
-
-   ;; Social sharing
-   :blog-image
-   {:desc "Blog thumbnail image URL; see Features > Social sharing in README"
-    :ref "<url>"
-    :group :social-sharing}
-
-   ;; Favicon
-   :favicon
-   {:desc "If true, favicon will be added to all pages"
-    :default false
-    :group :favicon}
-
-   :favicon-dir
-   {:desc "Directory to read favicon assets from"
-    :ref "<dir>"
-    :default (fs/file "assets" "favicon")
-    :group :favicon}
-
-   :favicon-out-dir
-   {:desc "Directory to write favicon assets to (relative to :out-dir)"
-    :ref "<dir>"
-    :default (fs/file "assets" "favicon")
-    :group :favicon}
-
-   ;; Command-specific opts
-   :file
-   {:desc "Filename of post (relative to posts-dir)"
-    :ref "<filename>"
-    :require true
-    :coerce (fn [s] (if (str/ends-with? s ".md")
-                      s
-                      (format "%s.md" s)))
-    :cmds #{"new"}}
-
-   :title
-   {:desc "Title of post"
-    :ref "<title>"
-    :require true
-    :cmds #{"new"}}
-
-   :port
-   {:desc "Port for HTTP server to listen on"
-    :ref "<port>"
-    :default 1888
-    :cmds #{"serve" "watch"}}
-   })
+(def ^:private specs (get-in (meta (the-ns 'quickblog.api))
+                             [:org.babashka/cli :spec]))
 
 (defn- apply-defaults [default-opts spec]
   (->> spec
@@ -189,23 +18,12 @@
                 [k v])))
        (into {})))
 
-(defn- global-opts [all-specs]
-  (->> all-specs
-       (filter (fn [[_opt spec]] (:group spec)))
-       (into {})))
-
-(defn- subcommand-opts [all-specs cmd-name]
-  (->> all-specs
-       (filter (fn [[_ {:keys [cmds]}]] (contains? cmds cmd-name)))
-       (into {})))
-
-(defn- ->subcommand-help [all-specs cmd]
-  (let [cmd-name (first (:cmds cmd))
-        cmd-opts (subcommand-opts all-specs cmd-name)
+(defn- ->subcommand-help [{:keys [cmds cmd-opts desc]}]
+  (let [cmd-name (first cmds)
         opts-str (if (empty? cmd-opts)
                    ""
                    (str "\n" (cli/format-opts {:spec cmd-opts, :indent 4})))]
-    (format "  %s: %s%s" cmd-name (:desc cmd) opts-str)))
+    (format "  %s: %s%s" cmd-name desc opts-str)))
 
 (defn- ->group-name [group]
   (-> group
@@ -213,8 +31,8 @@
       str/capitalize
       (str/replace "-" " ")))
 
-(defn- format-opts [all-specs]
-  (->> (global-opts all-specs)
+(defn- format-opts [global-specs]
+  (->> global-specs
        (group-by (fn [[_opt spec]] (:group spec)))
        (map (fn [[group opts]]
               (let [spec (into {} opts)]
@@ -223,7 +41,7 @@
                         (cli/format-opts {:spec spec})))))
        (str/join "\n\n")))
 
-(defn- print-help [all-specs cmds]
+(defn- print-help [global-specs cmds]
   (println
    (format
     "Usage: bb %s <subcommand> <options>
@@ -238,70 +56,72 @@ Options:
 "
     main-cmd-name
     (->> cmds
-         (map (partial ->subcommand-help all-specs))
+         (map ->subcommand-help)
          (str/join "\n"))
-    (format-opts all-specs)))
+    (format-opts global-specs)))
   (System/exit 0))
 
-(defn- print-command-help [cmd-name all-specs]
-  (let [cmd-opts (subcommand-opts all-specs cmd-name)
-        opts-str (if (empty? cmd-opts)
+(defn- print-command-help [cmd-name specs cmd-opts]
+  (let [opts-str (if (empty? cmd-opts)
                    ""
                    (format "Options:\n%s\n\n"
                            (cli/format-opts {:spec cmd-opts})))]
     (println
      (format "Usage: bb %s %s <options>\n\n%sGlobal options:\n\n%s"
-             main-cmd-name cmd-name opts-str (format-opts all-specs)))))
+             main-cmd-name cmd-name opts-str (format-opts specs)))))
 
-(defn- mk-cmd [all-specs [cmd-name desc f]]
-  {:cmds [cmd-name]
-   :desc desc
-   :spec (merge (global-opts all-specs) (subcommand-opts all-specs cmd-name))
-   :error-fn
-   (fn [{:keys [type cause msg option] :as data}]
-     (if (= :org.babashka/cli type)
-       (do
-         (case cause
-           :require
-           (println
-            (format "Missing required argument:\n%s"
-                    (cli/format-opts {:spec (select-keys all-specs [option])})))
-           (println msg))
-         (System/exit 1))
-       (throw (ex-info msg data))))
-   :fn (fn [{:keys [opts]}]
-         (when (:help opts)
-           (print-command-help cmd-name all-specs)
-           (System/exit 0))
-         (f opts))})
+(defn- mk-cmd [global-specs [cmd-name desc fn-var]]
+  (let [cmd-opts (get-in (meta fn-var) [:org.babashka/cli :spec])]
+    {:cmds [cmd-name]
+     :cmd-opts cmd-opts
+     :desc desc
+     :spec (merge global-specs cmd-opts)
+     :error-fn
+     (fn [{:keys [type cause msg option] :as data}]
+       (if (= :org.babashka/cli type)
+         (do
+           (case cause
+             :require
+             (println
+              (format "Missing required argument:\n%s"
+                      (cli/format-opts {:spec (select-keys global-specs [option])})))
+             (println msg))
+           (System/exit 1))
+         (throw (ex-info msg data))))
+     :fn (fn [{:keys [opts]}]
+           (when (:help opts)
+             (print-command-help cmd-name global-specs cmd-opts)
+             (System/exit 0))
+           ;; We need to deref the var to get the function out
+           (@fn-var opts))}))
 
 (defn- mk-table [default-opts]
-  (let [all-specs (apply-defaults default-opts specs)
+  (let [global-specs (apply-defaults default-opts specs)
         cmds
-        (mapv (partial mk-cmd all-specs)
+        (mapv (partial mk-cmd global-specs)
               [["render"
                 "Render the blog"
-                api/render]
+                #'api/render]
                ["new"
                 "Create new file in posts-dir"
-                api/new]
+                #'api/new]
                ["serve"
                 "Run HTTP server for rendered site"
-                api/serve]
+                #'api/serve]
                ["watch"
                 "Run HTTP server, watching posts, templates, and assets for changes"
-                api/watch]
+                #'api/watch]
                ["clean"
                 "Remove cache and output directories"
-                api/clean]
+                #'api/clean]
                ["refresh-templates"
                 "Update to latest default templates; see the Templates section in README"
-                api/refresh-templates]
+                #'api/refresh-templates]
                ["migrate"
                 "Migrate from `posts.edn` to post-local metadata"
-                api/migrate]])]
+                #'api/migrate]])]
     (conj cmds
-          {:cmds [], :fn (fn [m] (print-help all-specs cmds))})))
+          {:cmds [], :fn (fn [m] (print-help global-specs cmds))})))
 
 (defn dispatch
   ([]

--- a/src/quickblog/cli.clj
+++ b/src/quickblog/cli.clj
@@ -1,0 +1,315 @@
+(ns quickblog.cli
+  (:require [babashka.cli :as cli]
+            [babashka.fs :as fs]
+            [quickblog.api :as api]
+            [clojure.set :as set]
+            [clojure.string :as str]))
+
+(def ^:private main-cmd-name "quickblog")
+
+(def ^:private specs
+  {
+   ;; Blog metadata
+   :blog-title
+   {:desc "Title of the blog"
+    :ref "<title>"
+    :default "quickblog"
+    :require true
+    :group :blog-metadata}
+
+   :blog-author
+   {:desc "Author's name"
+    :ref "<name>"
+    :default "Quick Blogger"
+    :require true
+    :group :blog-metadata}
+
+   :blog-description
+   {:desc "Blog description for subtitle and RSS feeds"
+    :ref "<text>"
+    :default "A blog about blogging quickly"
+    :require true
+    :group :blog-metadata}
+
+   :blog-root
+   {:desc "Base URL of the blog"
+    :ref "<url>"
+    :default "https://github.com/borkdude/quickblog"
+    :require true
+    :group :blog-metadata}
+
+   ;; Optional metadata
+   :about-link
+   {:desc "Link to about the author page"
+    :ref "<url>"
+    :group :optional-metadata}
+
+   :discuss-link
+   {:desc "Link to discussion forum for posts"
+    :ref "<url>"
+    :group :optional-metadata}
+
+   :twitter-handle
+   {:desc "Author's Twitter handle"
+    :ref "<handle>"
+    :group :optional-metadata}
+
+   ;; Post config
+   :default-metadata
+   {:desc "Default metadata to add to posts"
+    :default {}
+    :group :post-config}
+
+   :num-index-posts
+   {:desc "Number of most recent posts to show on the index page"
+    :ref "<num>"
+    :default 3
+    :group :post-config}
+
+   :posts-file
+   {:desc "File containing deprecated post metadata (used only for `migrate`)"
+    :ref "<file>"
+    :default "posts.edn"
+    :group :post-config}
+
+   ;; Input directories
+   :assets-dir
+   {:desc "Directory to copy assets (images, etc.) from"
+    :default "assets"
+    :require true
+    :group :input-directories}
+
+   :posts-dir
+   {:desc "Directory to read posts from"
+    :ref "<dir>"
+    :default "posts"
+    :require true
+    :group :input-directories}
+
+   :templates-dir
+   {:desc "Directory to read templates from; see Templates section in README"
+    :default "templates"
+    :require true
+    :group :input-directories}
+
+   ;; Output directories
+   :out-dir
+   {:desc "Base directory for outputting static site"
+    :ref "<dir>"
+    :default "public"
+    :require true
+    :group :output-directories}
+
+   :assets-out-dir
+   {:desc "Directory to write assets to (relative to :out-dir)"
+    :ref "<dir>"
+    :default "assets"
+    :require true
+    :group :output-directories}
+
+   :tags-dir
+   {:desc "Directory to write tags to (relative to :out-dir)"
+    :default "tags"
+    :require true
+    :group :output-directories}
+
+   ;; Caching
+   :force-render
+   {:desc "If true, pages will be re-rendered regardless of cache status"
+    :default false
+    :group :caching}
+
+   :cache-dir
+   {:desc "Directory to use for caching"
+    :ref "<dir>"
+    :default ".work"
+    :require true
+    :group :caching}
+
+   :rendering-system-files
+   {:desc "Files involved in rendering pages (only set if you know what you're doing!)"
+    :ref "<file1> <file2>..."
+    :default ["bb.edn" "deps.edn"]
+    :coerce []
+    :require true
+    :group :caching}
+
+   ;; Social sharing
+   :blog-image
+   {:desc "Blog thumbnail image URL; see Features > Social sharing in README"
+    :ref "<url>"
+    :group :social-sharing}
+
+   ;; Favicon
+   :favicon
+   {:desc "If true, favicon will be added to all pages"
+    :default false
+    :group :favicon}
+
+   :favicon-dir
+   {:desc "Directory to read favicon assets from"
+    :ref "<dir>"
+    :default (fs/file "assets" "favicon")
+    :group :favicon}
+
+   :favicon-out-dir
+   {:desc "Directory to write favicon assets to (relative to :out-dir)"
+    :ref "<dir>"
+    :default (fs/file "assets" "favicon")
+    :group :favicon}
+
+   ;; Command-specific opts
+   :file
+   {:desc "Filename of post (relative to posts-dir)"
+    :ref "<filename>"
+    :require true
+    :coerce (fn [s] (if (str/ends-with? s ".md")
+                      s
+                      (format "%s.md" s)))
+    :cmds #{"new"}}
+
+   :title
+   {:desc "Title of post"
+    :ref "<title>"
+    :require true
+    :cmds #{"new"}}
+
+   :port
+   {:desc "Port for HTTP server to listen on"
+    :ref "<port>"
+    :default 1888
+    :cmds #{"serve" "watch"}}
+   })
+
+(defn- apply-defaults [default-opts spec]
+  (->> spec
+       (map (fn [[k v]]
+              (if-let [default-val (default-opts k)]
+                [k (assoc v :default default-val)]
+                [k v])))
+       (into {})))
+
+(defn- global-opts [all-specs]
+  (->> all-specs
+       (filter (fn [[_opt spec]] (:group spec)))
+       (into {})))
+
+(defn- subcommand-opts [all-specs cmd-name]
+  (->> all-specs
+       (filter (fn [[_ {:keys [cmds]}]] (contains? cmds cmd-name)))
+       (into {})))
+
+(defn- ->subcommand-help [all-specs cmd]
+  (let [cmd-name (first (:cmds cmd))
+        cmd-opts (subcommand-opts all-specs cmd-name)
+        opts-str (if (empty? cmd-opts)
+                   ""
+                   (str "\n" (cli/format-opts {:spec cmd-opts, :indent 4})))]
+    (format "  %s: %s%s" cmd-name (:desc cmd) opts-str)))
+
+(defn- ->group-name [group]
+  (-> group
+      name
+      str/capitalize
+      (str/replace "-" " ")))
+
+(defn- format-opts [all-specs]
+  (->> (global-opts all-specs)
+       (group-by (fn [[_opt spec]] (:group spec)))
+       (map (fn [[group opts]]
+              (let [spec (into {} opts)]
+                (format "%s\n%s"
+                        (->group-name group)
+                        (cli/format-opts {:spec spec})))))
+       (str/join "\n\n")))
+
+(defn- print-help [all-specs cmds]
+  (println
+   (format
+    "Usage: bb %s <subcommand> <options>
+
+Subcommands:
+
+%s
+
+Options:
+
+%s
+"
+    main-cmd-name
+    (->> cmds
+         (map (partial ->subcommand-help all-specs))
+         (str/join "\n"))
+    (format-opts all-specs)))
+  (System/exit 0))
+
+(defn- print-command-help [cmd-name all-specs]
+  (let [cmd-opts (subcommand-opts all-specs cmd-name)
+        opts-str (if (empty? cmd-opts)
+                   ""
+                   (format "Options:\n%s\n\n"
+                           (cli/format-opts {:spec cmd-opts})))]
+    (println
+     (format "Usage: bb %s %s <options>\n\n%sGlobal options:\n\n%s"
+             main-cmd-name cmd-name opts-str (format-opts all-specs)))))
+
+(defn- mk-cmd [all-specs [cmd-name desc f]]
+  {:cmds [cmd-name]
+   :desc desc
+   :spec (merge (global-opts all-specs) (subcommand-opts all-specs cmd-name))
+   :error-fn
+   (fn [{:keys [type cause msg option] :as data}]
+     (if (= :org.babashka/cli type)
+       (do
+         (case cause
+           :require
+           (println
+            (format "Missing required argument:\n%s"
+                    (cli/format-opts {:spec (select-keys all-specs [option])})))
+           (println msg))
+         (System/exit 1))
+       (throw (ex-info msg data))))
+   :fn (fn [{:keys [opts]}]
+         (when (:help opts)
+           (print-command-help cmd-name all-specs)
+           (System/exit 0))
+         (f opts))})
+
+(defn- mk-table [default-opts]
+  (let [all-specs (apply-defaults default-opts specs)
+        cmds
+        (mapv (partial mk-cmd all-specs)
+              [["render"
+                "Render the blog"
+                api/render]
+               ["new"
+                "Create new file in posts-dir"
+                api/new]
+               ["serve"
+                "Run HTTP server for rendered site"
+                api/serve]
+               ["watch"
+                "Run HTTP server, watching posts, templates, and assets for changes"
+                api/watch]
+               ["clean"
+                "Remove cache and output directories"
+                api/clean]
+               ["refresh-templates"
+                "Update to latest default templates; see the Templates section in README"
+                api/refresh-templates]
+               ["migrate"
+                "Migrate from `posts.edn` to post-local metadata"
+                api/migrate]])]
+    (conj cmds
+          {:cmds [], :fn (fn [m] (print-help all-specs cmds))})))
+
+(defn dispatch
+  ([]
+   (dispatch {}))
+  ([default-opts & args]
+   (cli/dispatch (mk-table default-opts)
+                 (or args
+                     (seq *command-line-args*)))))
+
+(defn -main [& args]
+  (apply dispatch {} args))


### PR DESCRIPTION
Adds a `quickblog.cli` namespace and a series of subcommands to call API functions. This removes the need for having one task per API function, allowing you to have a single task that dispatches all of the subcommands. All options are now documented as well.

Please answer the following questions and leave the below in as part of your PR.

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code): #17 

- [x] I have updated the [CHANGELOG.md](https://github.com/babashka/babashka/blob/master/CHANGELOG.md) file with a description of the addressed issue.
