### PR TITLE
Fix tags with spaces

### DIFF
--- a/resources/quickblog/templates/post.html
+++ b/resources/quickblog/templates/post.html
@@ -16,7 +16,7 @@
   Tagged:
   {% for tag in tags %}
   <span class="tag">
-    <a href="tags/{{tag}}.html">{{tag}}</a>
+    <a href="tags/{{tag|escape-tag}}.html">{{tag}}</a>
   </span>
   {% endfor %}
   </i>

--- a/src/quickblog/api.clj
+++ b/src/quickblog/api.clj
@@ -475,9 +475,17 @@
      :title
      {:desc "Title of post"
       :ref "<title>"
+      :require true}
+
+     :tags
+     {:desc "Comma separated list of tags"
+      :ref "<tags>"
+      :default "clojure"
       :require true}}}}
   [opts]
-  (let [{:keys [file title posts-dir] :as opts} (apply-default-opts opts)]
+  (let [{:keys [file title posts-dir tags]
+         :or {tags "clojure"}
+         :as opts} (apply-default-opts opts)]
     (doseq [k [:file :title]]
       (assert (contains? opts k) (format "Missing required option: %s" k)))
     (let [file (if (re-matches #"^.+[.][^.]+$" file)
@@ -487,8 +495,8 @@
       (when-not (fs/exists? post-file)
         (fs/create-dirs posts-dir)
         (spit (fs/file posts-dir file)
-              (format "Title: %s\nDate: %s\nTags: clojure\n\nWrite a blog post here!"
-                      title (now)))))))
+              (format "Title: %s\nDate: %s\nTags: %s\n\nWrite a blog post here!"
+                      title (now) tags))))))
 
 (defn clean
   "Removes cache and output directories"

--- a/src/quickblog/api.clj
+++ b/src/quickblog/api.clj
@@ -166,7 +166,12 @@
    [hiccup2.core :as hiccup]
    [markdown.core :as md]
    [quickblog.internal :as lib]
-   [selmer.parser :as selmer]))
+   [selmer.parser :as selmer]
+   [selmer.filters :as filters]))
+
+;; Add filter for tag page links; see:
+;; https://github.com/yogthos/Selmer#filters
+(filters/add-filter! :escape-tag lib/escape-tag)
 
 (defn- update-out-dirs
   [{:keys [out-dir assets-out-dir favicon-out-dir] :as opts}]

--- a/src/quickblog/internal.clj
+++ b/src/quickblog/internal.clj
@@ -97,9 +97,12 @@
 (defn cache-file [file]
   (str file ".pre-template.html"))
 
+(defn escape-tag [tag]
+  (str/replace tag #"[^A-z0-9]" "-"))
+
 (defn tag-file [tag]
   (-> tag
-      (str/replace #"[^A-z0-9]" "-")
+      escape-tag
       (str ".html")))
 
 (defn transform-metadata

--- a/test/quickblog/api_test.clj
+++ b/test/quickblog/api_test.clj
@@ -77,7 +77,7 @@
                 templates-dir
                 cache-dir
                 out-dir]
-      (write-test-post posts-dir)
+      (write-test-post posts-dir {:tags #{"clojure" "tag with spaces"}})
       (write-test-file assets-dir "asset.txt" "something")
       (api/render {:assets-dir assets-dir
                    :posts-dir posts-dir
@@ -91,8 +91,11 @@
       (doseq [filename ["test.html" "index.html" "archive.html"
                         (fs/file "tags" "index.html")
                         (fs/file "tags" "clojure.html")
+                        (fs/file "tags" "tag-with-spaces.html")
                         "atom.xml" "planetclojure.xml"]]
-        (is (fs/exists? (fs/file out-dir filename))))))
+        (is (fs/exists? (fs/file out-dir filename))))
+      (is (str/includes? (slurp (fs/file out-dir "test.html"))
+                         "<a href=\"tags/tag-with-spaces.html\">tag with spaces</a>"))))
 
   (testing "with favicon"
     (with-dirs [favicon-dir


### PR DESCRIPTION
This fix adds a Selmer filter that is used in the post template, so it will be necessary to update at that template. This can be done in either of the following two ways:

```
$ rm templates/post.html && bb quickblog render
```

You can also update all templates:

```
$ bb quickblog refresh-templates && bb quickblog render
```

Please answer the following questions and leave the below in as part of your PR.

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code): #31 

- [x] I have updated the [CHANGELOG.md](https://github.com/babashka/babashka/blob/master/CHANGELOG.md) file with a description of the addressed issue: n/a since this is a bugfix
