### PR TITLE
api/new accepts list of tags instead of comma separated string

### DIFF
--- a/src/quickblog/api.clj
+++ b/src/quickblog/api.clj
@@ -483,13 +483,13 @@
       :require true}
 
      :tags
-     {:desc "Comma separated list of tags"
+     {:desc "List of tags (example: --tag tag1 tag2 \"tag3 has spaces\")"
       :ref "<tags>"
-      :default "clojure"
+      :default ["clojure"]
       :require true}}}}
   [opts]
   (let [{:keys [file title posts-dir tags]
-         :or {tags "clojure"}
+         :or {tags ["clojure"]}
          :as opts} (apply-default-opts opts)]
     (doseq [k [:file :title]]
       (assert (contains? opts k) (format "Missing required option: %s" k)))
@@ -501,7 +501,7 @@
         (fs/create-dirs posts-dir)
         (spit (fs/file posts-dir file)
               (format "Title: %s\nDate: %s\nTags: %s\n\nWrite a blog post here!"
-                      title (now) tags))))))
+                      title (now) (str/join "," tags)))))))
 
 (defn clean
   "Removes cache and output directories"

--- a/test/quickblog/api_test.clj
+++ b/test/quickblog/api_test.clj
@@ -95,7 +95,9 @@
                         "atom.xml" "planetclojure.xml"]]
         (is (fs/exists? (fs/file out-dir filename))))
       (is (str/includes? (slurp (fs/file out-dir "test.html"))
-                         "<a href=\"tags/tag-with-spaces.html\">tag with spaces</a>"))))
+                         "<a href=\"tags/tag-with-spaces.html\">tag with spaces</a>"))
+      (is (str/includes? (slurp (fs/file out-dir "tags" "index.html"))
+                         "<a href=\"tag-with-spaces.html\">tag with spaces</a>"))))
 
   (testing "with favicon"
     (with-dirs [favicon-dir

--- a/test/quickblog/api_test.clj
+++ b/test/quickblog/api_test.clj
@@ -50,10 +50,11 @@
     (with-redefs [api/now (constantly "2022-01-02")]
       (api/new {:posts-dir posts-dir
                 :file "test.md"
-                :title "Test post"})
+                :title "Test post"
+                :tags ["clojure" "some other tag"]})
       (let [post-file (fs/file posts-dir "test.md")]
         (is (fs/exists? post-file))
-        (is (= "Title: Test post\nDate: 2022-01-02\nTags: clojure\n\nWrite a blog post here!"
+        (is (= "Title: Test post\nDate: 2022-01-02\nTags: clojure,some other tag\n\nWrite a blog post here!"
                (slurp post-file)))))))
 
 (deftest migrate


### PR DESCRIPTION
* `--tags` option to `bb quickblog new` accepts a list of tags rather than a comma separated string; for example:
  ```
  bb quickblog new --file test.md --title "This is a blog post" --tags tag1 tag2 "tag3 has spaces"
  ```
* Add test for tag with spaces in tags index page

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code): #31 

- [x] I have updated the [CHANGELOG.md](https://github.com/babashka/babashka/blob/master/CHANGELOG.md) file with a description of the addressed issue; n/a: minor fix for new CLI option
