### PR TITLE
Enables custom default tags and ability to add no tags (issue #51)

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -14,7 +14,7 @@
  {:quickblog
   {:deps {io.github.borkdude/quickblog
           {:local/root "."}
-          org.babashka/cli {:mvn/version "0.3.35"}}
+          org.babashka/cli {:mvn/version "0.6.41"}}
    :main-opts ["-m" "babashka.cli.exec" "quickblog.cli" "run"]
    :exec-args {:blog-title "REPL adventures"
                :blog-description "A blog about blogging quickly"

--- a/src/quickblog/api.clj
+++ b/src/quickblog/api.clj
@@ -50,7 +50,7 @@
      ;; Post config
      :default-metadata
      {:desc "Default metadata to add to posts"
-      :default {}
+      :default {:tags ["clojure"]}
       :group :post-config}
 
      :num-index-posts
@@ -489,9 +489,11 @@
       :ref "<tags>"
       :coerce []}}}}
   [opts]
-  (let [{:keys [file title posts-dir tags]
+  (let [{:keys [file title posts-dir tags default-metadata]
          :as opts} (apply-default-opts opts)
-        tags (if (empty? tags) ["clojure"] tags)]
+        tags (cond (empty? tags)   (:tags default-metadata)
+                   (= tags [true]) [] ;; `--tags` without arguments
+                   :else tags)]
     (doseq [k [:file :title]]
       (assert (contains? opts k) (format "Missing required option: %s" k)))
     (let [file (if (re-matches #"^.+[.][^.]+$" file)

--- a/src/quickblog/internal.clj
+++ b/src/quickblog/internal.clj
@@ -18,7 +18,7 @@
 
 (def ^:private metadata-transformers
   {:default first
-   :tags #(-> % first (str/split #",\s*") set)})
+   :tags #(if (empty? %) #{} (-> % first (str/split #",\s*") set))})
 
 (def ^:private required-metadata
   #{:date

--- a/test/quickblog/api_test.clj
+++ b/test/quickblog/api_test.clj
@@ -65,11 +65,12 @@
                                       :date "2022-01-02"
                                       :tags #{"clojure"}})
           post-file (write-test-file posts-dir "test.md"
-                                     "Write a blog post here!")]
+                                     "Write a blog post here!")
+          to-lines #(-> % str/split-lines set)]
       (api/migrate {:posts-dir posts-dir
                     :posts-file posts-edn})
-      (is (= "Title: Test post\nDate: 2022-01-02\nTags: clojure\n\nWrite a blog post here!"
-             (slurp post-file))))))
+      (is (= (to-lines "Title: Test post\nDate: 2022-01-02\nTags: clojure\n\nWrite a blog post here!")
+             (to-lines (slurp post-file)))))))
 
 (deftest render
   (testing "happy path"


### PR DESCRIPTION
The default tag will still remain `"clojure"`, but users can change it by adding `:default-metadata {:tags […]}` to their `opts` map in bb.edn, which also enables them to add multiple default tags or none at all (with an empty vector). I hope my changes are aligned with the intended use of `:default-metadata`.

For a single post, users can just add `--tags` without any arguments to omit tags even if the default vector is not empty. Maybe there could also be an option `--no-tags` for clarity of intent, but I don’t think it’s necessary.