### PR TITLE
Introduce templates for index, tags, and post-links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ Instances of quickblog can be seen here:
 - Improve visualization on mobile screens
 - Enable use of metadata in templates
 - Replace workaround that copies metadata from `api/serve`
+- Add templates that allow control over layout and styling of index page, pages with tags, and archive
+- Preserve HTML comments
+- Support showing previews of posts on index page
 
 ## 0.1.0 (2022-12-11)
 

--- a/README.md
+++ b/README.md
@@ -214,6 +214,12 @@ quickblog uses the following templates in site generation:
 - `style.css` - Styles for all pages.
 - `favicon.html` - If `:favicon true`, used to include favicon in the `<head>`
   of all pages.
+- `tags.html` - Tag overview page.
+- `post-links.html` - Used to render lists of blog posts in the archive and
+  each page corresponding to a single tag.
+- `index.html` - Index page. Posts containing the marker comment
+  `<!-- end-of-preview -->` are included on the index page up until the first
+  occurrence of that comment.
 
 quickblog looks for these templates in your `:templates-dir`, and if it doesn't
 find them, will copy a default template into that directory. It is recommended

--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,5 @@
 {:paths ["src" "resources"]
  :deps {rewrite-clj/rewrite-clj {:mvn/version "1.1.45"}
-        hiccup/hiccup {:mvn/version "2.0.0-alpha2"}
         babashka/fs {:mvn/version "0.1.6"}
         org.clojure/clojure {:mvn/version "1.11.1"}
         org.clojure/data.xml {:mvn/version "0.2.0-alpha6"}

--- a/resources/quickblog/templates/index.html
+++ b/resources/quickblog/templates/index.html
@@ -1,0 +1,23 @@
+{% for post in posts %}
+    <div>
+        <h1><a href="{{post.post-link}}">{{post.title}}</a></h1>
+        {{post.body | safe}}
+        {% if post.truncated %}
+            <p><a href="{{post.post-link}}">Continue reading</a></p>
+        {% endif %}
+        {% if post.discuss %}
+            <p>Discuss this post <a href="{{post.discuss}}">here</a>.</p>
+        {% endif %}
+        <p><i>Published: {{post.date}}</i></p>
+        {% if post.tags %}
+            <p><i>
+                Tagged:
+                {% for tag in post.tags %}
+                    <span class="tag">
+                        <a href="tags/{{tag|escape-tag}}.html">{{tag}}</a>
+                    </span>
+                {% endfor %}
+            </i></p>
+        {% endif %}
+    </div>
+{% endfor %}

--- a/resources/quickblog/templates/post-links.html
+++ b/resources/quickblog/templates/post-links.html
@@ -1,6 +1,6 @@
 <div style="width: 600px">
     <h1>{{title}}</h1>
-    <ul>
+    <ul class="index">
         {% for post-link in post-links %}
             <li><span><a href="{{post-link.url}}">{{post-link.title}}</a> - {{post-link.date}}</span></li>
         {% endfor %}

--- a/resources/quickblog/templates/post-links.html
+++ b/resources/quickblog/templates/post-links.html
@@ -1,0 +1,8 @@
+<div style="width: 600px">
+    <h1>{{title}}</h1>
+    <ul>
+        {% for post-link in post-links %}
+            <li><span><a href="{{post-link.url}}">{{post-link.title}}</a> - {{post-link.date}}</span></li>
+        {% endfor %}
+    </ul>
+</div>

--- a/resources/quickblog/templates/tags.html
+++ b/resources/quickblog/templates/tags.html
@@ -2,7 +2,7 @@
     <h1>{{title}}</h1>
     <ul>
         {% for tag in tags %}
-            <li><span><a href="{{tag.url}}">{{tag.tag}}</a> - {{tag.count}} posts</span></li>
+            <li><span><a href="{{tag.url}}">{{tag.tag}}</a> - {{tag.count}} post{{tag.count|pluralize}}</span></li>
         {% endfor %}
     </ul>
 </div>

--- a/resources/quickblog/templates/tags.html
+++ b/resources/quickblog/templates/tags.html
@@ -1,0 +1,8 @@
+<div style="width: 600px">
+    <h1>{{title}}</h1>
+    <ul>
+        {% for tag in tags %}
+            <li><span><a href="{{tag.url}}">{{tag.tag}}</a> - {{tag.count}} posts</span></li>
+        {% endfor %}
+    </ul>
+</div>

--- a/resources/quickblog/templates/tags.html
+++ b/resources/quickblog/templates/tags.html
@@ -1,6 +1,6 @@
 <div style="width: 600px">
     <h1>{{title}}</h1>
-    <ul>
+    <ul class="index">
         {% for tag in tags %}
             <li><span><a href="{{tag.url}}">{{tag.tag}}</a> - {{tag.count}} post{{tag.count|pluralize}}</span></li>
         {% endfor %}

--- a/src/quickblog/api.clj
+++ b/src/quickblog/api.clj
@@ -338,7 +338,8 @@
 
 (defn- spit-archive [{:keys [blog-title blog-description
                              blog-image blog-image-alt twitter-handle
-                             modified-metadata posts out-dir] :as opts}]
+                             templates-dir modified-metadata posts out-dir]
+                      :as opts}]
   (let [out-file (fs/file out-dir "archive.html")
         stale? (or (some not-empty (vals modified-metadata))
                    (not (fs/exists? out-file)))]
@@ -349,7 +350,7 @@
                          (base-html opts)
                          {:skip-archive true
                           :title title
-                          :body (hiccup/html (lib/post-links "Archive" posts))
+                          :body (lib/post-links "Archive" posts templates-dir)
                           :sharing {:description (format "Archive - %s"
                                                          blog-description)
                                     :author twitter-handle

--- a/src/quickblog/api.clj
+++ b/src/quickblog/api.clj
@@ -163,8 +163,6 @@
    [clojure.edn :as edn]
    [clojure.set :as set]
    [clojure.string :as str]
-   [hiccup2.core :as hiccup]
-   [markdown.core :as md]
    [quickblog.internal :as lib]
    [selmer.parser :as selmer]
    [selmer.filters :as filters]))

--- a/src/quickblog/api.clj
+++ b/src/quickblog/api.clj
@@ -227,7 +227,7 @@
                            (fs/file "assets" "favicon" asset)))))
 
 (defn- gen-posts [{:keys [deleted-posts modified-posts posts
-                          cache-dir out-dir templates-dir]
+                          cache-dir out-dir]
                    :as opts}]
   (let [posts-to-write (set/union modified-posts
                                   (lib/modified-post-pages opts))
@@ -259,8 +259,7 @@
 
 (defn- gen-tags [{:keys [blog-title blog-description
                          blog-image blog-image-alt twitter-handle
-                         modified-tags posts out-dir tags-dir
-                         templates-dir]
+                         modified-tags posts out-dir tags-dir]
                   :as opts}]
   (let [tags-out-dir (fs/create-dirs (fs/file out-dir tags-dir))
         posts-by-tag (lib/posts-by-tag posts)
@@ -272,7 +271,7 @@
                        {:skip-archive true
                         :title (str blog-title " - Tags")
                         :relative-path "../"
-                        :body (lib/tag-links "Tags" posts-by-tag templates-dir)
+                        :body (lib/tag-links "Tags" posts-by-tag opts)
                         :sharing {:description (format "Tags - %s"
                                                        blog-description)
                                   :author twitter-handle
@@ -290,14 +289,14 @@
 
 ;;;; Generate index page with last `num-index-posts` posts
 
-(defn- index [{:keys [posts templates-dir]}]
+(defn- index [{:keys [posts] :as opts}]
   (let [posts (for [{:keys [file html] :as post} posts
                     :let [preview (first (str/split @html #"<!-- end-of-preview -->" 2))]]
                 (assoc post
                        :post-link (str/replace file ".md" ".html")
                        :body preview
                        :truncated (not= preview @html)))
-        index-template (lib/ensure-resource (fs/file templates-dir "index.html"))]
+        index-template (lib/ensure-template opts "index.html")]
     (selmer/render (slurp index-template) {:posts posts})))
 
 (defn- spit-index
@@ -333,7 +332,7 @@
 
 (defn- spit-archive [{:keys [blog-title blog-description
                              blog-image blog-image-alt twitter-handle
-                             templates-dir modified-metadata posts out-dir]
+                             modified-metadata posts out-dir]
                       :as opts}]
   (let [out-file (fs/file out-dir "archive.html")
         stale? (or (some not-empty (vals modified-metadata))
@@ -345,7 +344,7 @@
                          (base-html opts)
                          {:skip-archive true
                           :title title
-                          :body (lib/post-links "Archive" posts templates-dir)
+                          :body (lib/post-links "Archive" posts opts)
                           :sharing {:description (format "Archive - %s"
                                                          blog-description)
                                     :author twitter-handle

--- a/src/quickblog/api.clj
+++ b/src/quickblog/api.clj
@@ -261,7 +261,8 @@
 
 (defn- gen-tags [{:keys [blog-title blog-description
                          blog-image blog-image-alt twitter-handle
-                         modified-tags posts out-dir tags-dir]
+                         modified-tags posts out-dir tags-dir
+                         templates-dir]
                   :as opts}]
   (let [tags-out-dir (fs/create-dirs (fs/file out-dir tags-dir))
         posts-by-tag (lib/posts-by-tag posts)
@@ -273,7 +274,7 @@
                        {:skip-archive true
                         :title (str blog-title " - Tags")
                         :relative-path "../"
-                        :body (hiccup/html (lib/tag-links "Tags" posts-by-tag))
+                        :body (lib/tag-links "Tags" posts-by-tag templates-dir)
                         :sharing {:description (format "Tags - %s"
                                                        blog-description)
                                   :author twitter-handle

--- a/src/quickblog/api.clj
+++ b/src/quickblog/api.clj
@@ -227,7 +227,7 @@
                            (fs/file "assets" "favicon" asset)))))
 
 (defn- gen-posts [{:keys [deleted-posts modified-posts posts
-                          cache-dir posts-dir out-dir templates-dir]
+                          cache-dir out-dir templates-dir]
                    :as opts}]
   (let [posts-to-write (set/union modified-posts
                                   (lib/modified-post-pages opts))

--- a/src/quickblog/internal.clj
+++ b/src/quickblog/internal.clj
@@ -342,21 +342,18 @@
         slurp
         (selmer/render opts))))
 
-(defn post-links
-  ([title posts templates-dir]
-   (post-links title posts templates-dir {}))
-  ([title posts templates-dir {:keys [relative-path]}]
-   (let [post-links-template (ensure-resource (fs/file templates-dir "post-links.html"))
-         post-links (for [{:keys [file title date preview]} posts
-                          :when (not preview)]
-                      {:url (str relative-path (str/replace file ".md" ".html"))
-                       :title title
-                       :date date})]
-     (selmer/render (slurp post-links-template) {:title title
-                                                 :post-links post-links}))))
+(defn post-links [title posts {:keys [relative-path] :as opts}]
+  (let [post-links-template (ensure-template opts "post-links.html")
+        post-links (for [{:keys [file title date preview]} posts
+                         :when (not preview)]
+                     {:url (str relative-path (str/replace file ".md" ".html"))
+                      :title title
+                      :date date})]
+    (selmer/render (slurp post-links-template) {:title title
+                                                :post-links post-links})))
 
-(defn tag-links [title tags templates-dir]
-  (let [tags-template (ensure-resource (fs/file templates-dir "tags.html"))
+(defn tag-links [title tags opts]
+  (let [tags-template (ensure-template opts "tags.html")
         tags (map (fn [[tag posts]] {:url (str (escape-tag tag) ".html")
                                      :tag tag
                                      :count (count posts)}) tags)]
@@ -404,7 +401,7 @@
 
 (defn write-tag! [{:keys [blog-title blog-description
                           blog-image blog-image-alt twitter-handle
-                          templates-dir modified-tags] :as opts}
+                          modified-tags] :as opts}
                   tags-out-dir
                   template
                   [tag posts]]
@@ -415,7 +412,7 @@
                     :title (str blog-title " - Tag - " tag)
                     :relative-path "../"
                     :body (post-links (str "Tag - " tag) posts
-                                      templates-dir {:relative-path "../"})
+                                      (assoc opts :relative-path "../"))
                     :sharing {:description (format "Posts tagged \"%s\" - %s"
                                                    tag blog-description)
                               :author twitter-handle

--- a/src/quickblog/internal.clj
+++ b/src/quickblog/internal.clj
@@ -125,6 +125,9 @@
 
 (defn post-process-markdown [html]
   (-> html
+      ;; restore comments
+      (str/replace #"(<p>)?<!&ndash;(.*?)&ndash;>(</p>)?" "<!--$2-->")
+      ;; restore newline in multiline link titles
       (str/replace "$$RET$$" "\n")))
 
 (defn markdown->html [file]

--- a/src/quickblog/internal.clj
+++ b/src/quickblog/internal.clj
@@ -7,7 +7,6 @@
    [clojure.java.io :as io]
    [clojure.set :as set]
    [clojure.string :as str]
-   [hiccup2.core :as hiccup]
    [markdown.core :as md]
    [selmer.parser :as selmer]))
 

--- a/src/quickblog/internal.clj
+++ b/src/quickblog/internal.clj
@@ -355,16 +355,13 @@
              " - "
              date]])]]))
 
-(defn tag-links [title tags]
-  [:div {:style "width: 600px;"}
-   [:h1 title]
-   [:ul.index
-    (for [[tag posts] tags]
-      [:li [:span
-            [:a {:href (str (escape-tag tag) ".html")} tag]
-            " - "
-            (count posts)
-            " posts"]])]])
+(defn tag-links [title tags templates-dir]
+  (let [tags-template (ensure-resource (fs/file templates-dir "tags.html"))
+        tags (map (fn [[tag posts]] {:url (str (escape-tag tag) ".html")
+                                     :tag tag
+                                     :count (count posts)}) tags)]
+    (selmer/render (slurp tags-template) {:title title
+                                          :tags tags})))
 
 (defn render-page [opts template template-vars]
   (let [template-vars (merge opts template-vars)

--- a/test/quickblog/api_test.clj
+++ b/test/quickblog/api_test.clj
@@ -121,7 +121,34 @@
           (is (fs/exists? (fs/file favicon-dir filename)))
           (is (fs/exists? (fs/file favicon-out-dir filename))))
         (is (str/includes? (slurp (fs/file out-dir "index.html"))
-                           "favicon-16x16.png"))))))
+                           "favicon-16x16.png")))))
+
+  (testing "multiline links"
+    (with-dirs [posts-dir
+                templates-dir
+                cache-dir
+                out-dir]
+      (write-test-post posts-dir {:file "multiline.md"
+                                  :content "[a \n\n multiline \n\n link](www.example.org)"})
+      (api/render {:posts-dir posts-dir
+                   :templates-dir templates-dir
+                   :cache-dir cache-dir
+                   :out-dir out-dir})
+      (is (str/includes? (slurp (fs/file out-dir "multiline.html"))
+                         "<a href='www.example.org'>a \n\n multiline \n\n link</a>"))))
+  
+  (testing "comments"
+    (with-dirs [posts-dir
+                templates-dir
+                cache-dir
+                out-dir]
+      (write-test-post posts-dir {:file "comments.md"
+                                  :content "<!-- a comment -->"})
+      (api/render {:posts-dir posts-dir
+                   :templates-dir templates-dir
+                   :cache-dir cache-dir
+                   :out-dir out-dir})
+      (is (str/includes? (slurp (fs/file out-dir "comments.html")) "<!-- a comment -->")))))
 
 ;; disabled, flaky in CI, cc @jmglov
 #_(deftest caching

--- a/test/quickblog/api_test.clj
+++ b/test/quickblog/api_test.clj
@@ -123,6 +123,24 @@
         (is (str/includes? (slurp (fs/file out-dir "index.html"))
                            "favicon-16x16.png")))))
 
+  (testing "preview"
+    (with-dirs [posts-dir
+                templates-dir
+                cache-dir
+                out-dir]
+      (write-test-post posts-dir {:file "preview.md"
+                                  :content (str "always included\n\n"
+                                                "<!-- end-of-preview -->\n\n"
+                                                "only part of full post")})
+      (api/render {:posts-dir posts-dir
+                   :templates-dir templates-dir
+                   :cache-dir cache-dir
+                   :out-dir out-dir})
+      (is (str/includes? (slurp (fs/file out-dir "preview.html")) "<p>always included</p>"))
+      (is (str/includes? (slurp (fs/file out-dir "preview.html")) "<p>only part of full post</p>"))
+      (is (str/includes? (slurp (fs/file out-dir "index.html")) "<p>always included</p>"))
+      (is (not (str/includes? (slurp (fs/file out-dir "index.html")) "<p>only part of full post</p>")))))
+  
   (testing "multiline links"
     (with-dirs [posts-dir
                 templates-dir


### PR DESCRIPTION
This is related to https://github.com/borkdude/quickblog/issues/10, but has a slightly bigger scope. I'd like to be able to modify and more extensively style the pages with tags and the archive too (https://github.com/borkdude/quickblog/issues/61).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] I have updated the [CHANGELOG.md](https://github.com/babashka/babashka/blob/master/CHANGELOG.md) file with a description of the addressed issue.
