### PR TITLE
Detect posts with missing pre-template.html files in cache as stale

### DIFF
--- a/src/quickblog/internal.clj
+++ b/src/quickblog/internal.clj
@@ -169,6 +169,7 @@
         file (fs/file-name path)
         cached-file (fs/file cache-dir (cache-file file))
         stale? (or force-render
+                   (not (fs/exists? cached-file))
                    (rendering-modified? cached-file (cons path rendering-system-files)))]
     (println "Reading metadata for post:" (str file))
     (try


### PR DESCRIPTION
Please answer the following questions and leave the below in as part of your PR.

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code): #68 

- [x] I have updated the [CHANGELOG.md](https://github.com/babashka/babashka/blob/master/CHANGELOG.md) file with a description of the addressed issue. N/A: bugfix only
