### PR TITLE
Fix bug where setting default for command-specific opt wasn't honoured

### DIFF
--- a/src/quickblog/cli.clj
+++ b/src/quickblog/cli.clj
@@ -70,12 +70,12 @@ Options:
      (format "Usage: bb %s %s <options>\n\n%sGlobal options:\n\n%s"
              main-cmd-name cmd-name opts-str (format-opts specs)))))
 
-(defn- mk-cmd [global-specs [cmd-name desc fn-var]]
+(defn- mk-cmd [global-specs default-opts [cmd-name desc fn-var]]
   (let [cmd-opts (get-in (meta fn-var) [:org.babashka/cli :spec])]
     {:cmds [cmd-name]
      :cmd-opts cmd-opts
      :desc desc
-     :spec (merge global-specs cmd-opts)
+     :spec (merge global-specs (apply-defaults default-opts cmd-opts))
      :error-fn
      (fn [{:keys [type cause msg option] :as data}]
        (if (= :org.babashka/cli type)
@@ -100,7 +100,7 @@ Options:
 (defn- mk-table [default-opts]
   (let [global-specs (apply-defaults default-opts specs)
         cmds
-        (mapv (partial mk-cmd global-specs)
+        (mapv (partial mk-cmd global-specs default-opts)
               [["render"
                 "Render the blog"
                 #'api/render]


### PR DESCRIPTION
For example, given a function with the following spec:

``` clojure
(defn process-file
  {:org.babashka/cli
   {:spec
    {:media-file
     {:desc "Media file to transribe"
      :ref "<file>"
      :require true}}}}
  [{:keys [media-file] :as opts}]
  media-file)
```

Calling `cli/dispatch` like so would result in `process-file` returning `nil`:

``` clojure
(cli/dispatch {:media-file "some-file.mp4"})
```

Please answer the following questions and leave the below in as part of your PR.

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code): #70 

- [ ] I have updated the [CHANGELOG.md](https://github.com/babashka/babashka/blob/master/CHANGELOG.md) file with a description of the addressed issue. N/A: bugfix.
