### PR TITLE
Add configuration option for :page-suffix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,17 @@ Instances of quickblog can be seen here:
 - [Michiel Borkent's blog](https://blog.michielborkent.nl)
 - [Josh Glover's blog](https://jmglov.net/blog)
 - [Jeremy Taylor's blog](https://jdt.me/strange-reflections.html)
-- [Luc Engelen's blog](https://blog.cofx.nl/) ([source](https://github.com/cofx22/blog))
+- [JP Monetta's blog](https://jpmonettas.github.io/my-blog/public/)
+- [Luc Engelen's blog](https://blog.cofx.nl/) - ([source](https://github.com/cofx22/blog))
 - [Rattlin.blog](https://rattlin.blog/)
+- [REP‘ti’L‘e’](https://kuna.us/)
+- [Søren Sjørup's blog](https://zoren.dk)
+- [Henry Widd's blog](https://widdindustries.com/blog)
+- [Anders means different](https://www.eknert.com/blog) - ([source](https://github.com/anderseknert/blog))
 
 ## Unreleased
 
+- [#78](https://github.com/borkdude/quickblog/issues/78): Allow configurable :page-suffix to omit `.html` from page links
 - [#76](https://github.com/borkdude/quickblog/pull/76): Remove livejs script tag
   on render. ([@jmglov](https://github.com/jmglov))
 - [#75](https://github.com/borkdude/quickblog/pull/75): Omit preview posts from

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Instances of quickblog can be seen here:
 - [REP‘ti’L‘e’](https://kuna.us/)
 - [Søren Sjørup's blog](https://zoren.dk)
 - [Henry Widd's blog](https://widdindustries.com/blog)
-- [Anders means different](https://www.eknert.com/blog/bronchitis)
+- [Anders means different](https://www.eknert.com/blog) - ([source](https://github.com/anderseknert/blog))
 
 Feel free to PR yours.
 

--- a/resources/quickblog/templates/base.html
+++ b/resources/quickblog/templates/base.html
@@ -47,7 +47,7 @@
     <div class="site-header">
       <div class="wrapper">
         <div class="site-nav">
-          <a class="page-link" href="{{relative-path | safe}}archive.html">Archive</a>
+          <a class="page-link" href="{{relative-path | safe}}archive{{page-suffix}}">Archive</a>
           <a class="page-link" href="{{relative-path | safe}}tags/index.html">Tags</a>
           <a class="page-link" href="{{discuss-link}}">Discuss</a>
 	  <a class="page-link" href="{{relative-path | safe}}atom.xml">
@@ -77,7 +77,7 @@
 
       {% if not skip-archive %}
       <div style="margin-bottom: 20px; float: right;">
-        <a class="page-link" href="{{relative-path | safe}}archive.html">Archive</a>
+        <a class="page-link" href="{{relative-path | safe}}archive{{page-suffix}}">Archive</a>
       </div>
       {% endif %}
     </div>

--- a/resources/quickblog/templates/index.html
+++ b/resources/quickblog/templates/index.html
@@ -14,7 +14,7 @@
                 Tagged:
                 {% for tag in post.tags %}
                     <span class="tag">
-                        <a href="tags/{{tag|escape-tag}}.html">{{tag}}</a>
+                        <a href="tags/{{tag|escape-tag}}{{page-suffix}}">{{tag}}</a>
                     </span>
                 {% endfor %}
             </i></p>

--- a/resources/quickblog/templates/post.html
+++ b/resources/quickblog/templates/post.html
@@ -16,7 +16,7 @@
   Tagged:
   {% for tag in tags %}
   <span class="tag">
-    <a href="tags/{{tag|escape-tag}}.html">{{tag}}</a>
+    <a href="tags/{{tag|escape-tag}}{{page-suffix}}">{{tag}}</a>
   </span>
   {% endfor %}
   </i>

--- a/src/quickblog/internal.clj
+++ b/src/quickblog/internal.clj
@@ -363,11 +363,11 @@
         slurp
         (selmer/render opts))))
 
-(defn post-links [title posts {:keys [relative-path] :as opts}]
+(defn post-links [title posts {:keys [relative-path page-suffix] :as opts}]
   (let [post-links-template (ensure-template opts "post-links.html")
         post-links (for [{:keys [file title date preview]} posts
                          :when (not preview)]
-                     {:url (str relative-path (str/replace file ".md" ".html"))
+                     {:url (str relative-path (str/replace file ".md" page-suffix))
                       :title title
                       :date date})]
     (selmer/render (slurp post-links-template) {:title title
@@ -375,7 +375,7 @@
 
 (defn tag-links [title tags opts]
   (let [tags-template (ensure-template opts "tags.html")
-        tags (map (fn [[tag posts]] {:url (str (escape-tag tag) ".html")
+        tags (map (fn [[tag posts]] {:url (str (escape-tag tag) (:page-suffix opts))
                                      :tag tag
                                      :count (count posts)}) tags)]
     (selmer/render (slurp tags-template) {:title title
@@ -390,13 +390,14 @@
 (defn write-post! [{:keys [twitter-handle
                            discuss-link
                            out-dir
+                           page-suffix
                            page-template
                            post-template]
                     :as opts}
                    {:keys [file html description image image-alt]
                     :as post-metadata}]
   (let [out-file (fs/file out-dir (html-file file))
-        post-metadata (merge {:discuss discuss-link} (assoc post-metadata :body @html))
+        post-metadata (merge {:discuss discuss-link :page-suffix page-suffix} (assoc post-metadata :body @html))
         body (selmer/render post-template post-metadata)
         author (-> (:twitter-handle post-metadata) (or twitter-handle))
         image (when image (if (re-matches #"^https?://.+" image)

--- a/test/quickblog/api_test.clj
+++ b/test/quickblog/api_test.clj
@@ -113,6 +113,31 @@
         (is (not (str/includes? (slurp (fs/file out-dir filename))
                                 "preview.html"))))))
 
+  (testing "with blank page suffix"
+    (with-dirs [posts-dir
+                templates-dir
+                out-dir]
+       (write-test-post posts-dir {:tags #{"foobar" "tag with spaces"}})
+       (api/render {:page-suffix ""
+                    :posts-dir posts-dir
+                    :templates-dir templates-dir
+                    :out-dir out-dir})
+       (doseq [filename ["test.html" "index.html" "archive.html"
+                         (fs/file "tags" "index.html")
+                         (fs/file "tags" "tag-with-spaces.html")
+                         "atom.xml" "planetclojure.xml"]]
+         (is (fs/exists? (fs/file out-dir filename))))
+       (is (str/includes? (slurp (fs/file out-dir "test.html"))
+                          "<a class=\"page-link\" href=\"archive\">Archive</a>"))
+       (is (str/includes? (slurp (fs/file out-dir "test.html"))
+                          "<a href=\"tags/foobar\">foobar</a>"))
+       (is (str/includes? (slurp (fs/file out-dir "test.html"))
+                          "<a href=\"tags/tag-with-spaces\">tag with spaces</a>"))
+       (is (str/includes? (slurp (fs/file out-dir "tags" "index.html"))
+                          "<a href=\"foobar\">foobar</a>"))
+       (is (str/includes? (slurp (fs/file out-dir "tags" "index.html"))
+                          "<a href=\"tag-with-spaces\">tag with spaces</a>"))))
+
   (testing "with favicon"
     (with-dirs [favicon-dir
                 posts-dir
@@ -152,7 +177,7 @@
       (is (str/includes? (slurp (fs/file out-dir "preview.html")) "<p>only part of full post</p>"))
       (is (str/includes? (slurp (fs/file out-dir "index.html")) "<p>always included</p>"))
       (is (not (str/includes? (slurp (fs/file out-dir "index.html")) "<p>only part of full post</p>")))))
-  
+
   (testing "multiline links"
     (with-dirs [posts-dir
                 templates-dir
@@ -181,7 +206,7 @@
                    :cache-dir cache-dir
                    :out-dir out-dir})
       (is (str/includes? (slurp (fs/file out-dir "planetclojure.xml")) "Post about ClojureScript"))))
-  
+
     (testing "non-Clojure tag"
       (with-dirs [assets-dir
                   posts-dir


### PR DESCRIPTION
Default setting is ".html" to keep current behavior. Use empty string to omit extension.

There's still a few "index.html" links in the templates, but as those are easily replaced there directly, I don't think we'll need to add an option for that.

Fixes #78 

Please answer the following questions and leave the below in as part of your PR.

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] I have updated the [CHANGELOG.md](https://github.com/babashka/babashka/blob/master/CHANGELOG.md) file with a description of the addressed issue.
