### PR TITLE
Fix test runner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Instances of quickblog can be seen here:
 
 ## Unreleased
 
+- Fix argument passing in test runner ([@jmglov](https://github.com/jmglov))
 - Add `--date` to api/new. ([@jmglov](https://github.com/jmglov))
 - Support Selmer template for new posts in api/new; see [Templates > New
   posts](README.md#new-posts) in README. ([@jmglov](https://github.com/jmglov))

--- a/test/quickblog/test_runner.clj
+++ b/test/quickblog/test_runner.clj
@@ -1,11 +1,11 @@
 (ns quickblog.test-runner
-  {:org.babashka/cli {:coerce {:dirs :strings
-                               :nses :symbols
-                               :patterns :strings
-                               :vars :symbols
-                               :includes :keywords
-                               :excludes :keywords
-                               :only :symbols}}}
+  {:org.babashka/cli {:coerce {:dirs [:string]
+                               :nses [:symbol]
+                               :patterns [:string]
+                               :vars [:symbol]
+                               :includes [:keyword]
+                               :excludes [:keyword]
+                               :only :symbol}}}
   (:refer-clojure :exclude [test])
   (:require
    [clojure.test :as test]


### PR DESCRIPTION
See https://github.com/babashka/cli/pull/79

Running a single test now works:

```
$ bb test --only quickblog.api-test/migrate

Running tests in #{"test"}

Testing quickblog.api-test

Ran 1 tests containing 1 assertions.
0 failures, 0 errors.
```

- [x] This PR corresponds to an [issue with a clear problem statement] #92 

- [x] I have updated the [CHANGELOG.md](https://github.com/babashka/babashka/blob/master/CHANGELOG.md) file with a description of the addressed issue.
