### PR TITLE
Add an option to link previous and next posts in post metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ Instances of quickblog can be seen here:
 
 ## Unreleased
 
+- Link to previous and next posts; see "Linking to previous and next posts" in
+  the README ([@jmglov](https://github.com/jmglov))
 - Fix flaky caching tests ([@jmglov](https://github.com/jmglov))
 - Fix argument passing in test runner ([@jmglov](https://github.com/jmglov))
 - Add `--date` to api/new. ([@jmglov](https://github.com/jmglov))

--- a/README.md
+++ b/README.md
@@ -218,6 +218,26 @@ Resources for understanding and testing social sharing:
 - [LinkedIn Post Inspector](https://www.linkedin.com/post-inspector/)
 - [Twitter Card Validator](https://cards-dev.twitter.com/validator)
 
+### Linking to previous and next posts
+
+If you set the `:link-prev-next-posts` option to `true`, quickblog adds `prev`
+and `next` metadata to each post (where `prev` is the previous post and `next`
+is the next post in date order, oldest to newest). You can make use of these by
+adding something similar to this to your `post.html` template:
+
+``` html
+{% if any prev next %}
+  <div class="post-prev-next">
+{% if prev %}
+    <div>⏪ <a href="{{prev.file|replace:.md:.html}}">{{prev.title}}</a></div>
+{% endif %}
+{% if next %}
+    <div><a href="{{next.file|replace:.md:.html}}">{{next.title}}</a> ⏩</div>
+{% endif %}
+  </div>
+{% endif %}
+```
+
 ## Templates
 
 quickblog uses the following templates in site generation:

--- a/src/quickblog/api.clj
+++ b/src/quickblog/api.clj
@@ -324,6 +324,7 @@
   (let [index-posts #(->> (vals %)
                           lib/remove-previews
                           lib/sort-posts
+                          (map (partial lib/expand-prev-next-metadata opts))
                           (take num-index-posts))
         posts (index-posts posts)
         cached-posts (index-posts cached-posts)

--- a/test/quickblog/api_test.clj
+++ b/test/quickblog/api_test.clj
@@ -313,6 +313,7 @@
         (Thread/sleep 5)
         (write-test-post posts-dir)
         (write-test-file assets-dir "asset.txt" "something")
+        (Thread/sleep 500)
         (render)
         (let [asset-file (fs/file out-dir "assets" "asset.txt")
               mtime (fs/last-modified-time asset-file)]
@@ -356,6 +357,7 @@
                                              (->mtimes (fs/file out-dir "tags")
                                                        ["clojure.html"]))]
           ;; Shouldn't rewrite anything when post unmodified
+          (Thread/sleep 500)
           (render)
           (doseq [[filename mtime] (merge content-cached clojure-metadata-cached)]
             (is (= (map str [filename mtime])
@@ -363,6 +365,7 @@
           ;; Should rewrite all but metadata-cached files when post modified
           (Thread/sleep 5)
           (write-test-post posts-dir)
+          (Thread/sleep 500)
           (render)
           (doseq [[filename mtime] content-cached]
             (is (not= (map str [filename mtime])
@@ -373,6 +376,7 @@
           ;; Should rewrite everything when metadata modified
           (Thread/sleep 5)
           (write-test-post posts-dir {:title "Changed", :tags #{"not-clojure"}})
+          (Thread/sleep 500)
           (render)
           (doseq [[filename mtime] (merge content-cached metadata-cached)]
             (is (not= (map str [filename mtime])
@@ -430,6 +434,7 @@
                                     :tags #{"clojure"}})
         (write-test-post posts-dir {:file "random2.md"
                                     :tags #{"something"}})
+        (Thread/sleep 500)
         (let [mtimes (->mtimes out-dir ["atom.xml" "planetclojure.xml"])
               _ (render)
               mtimes-after (->mtimes out-dir ["atom.xml" "planetclojure.xml"])]
@@ -445,6 +450,7 @@
                  "clojure2.html"
                  "clojurescript1.html"}
                (post-ids (fs/file out-dir "planetclojure.xml"))))
+        (Thread/sleep 500)
         (let [mtimes (->mtimes out-dir ["atom.xml" "planetclojure.xml"])
               _ (render)
               mtimes-after (->mtimes out-dir ["atom.xml" "planetclojure.xml"])]

--- a/test/quickblog/api_test.clj
+++ b/test/quickblog/api_test.clj
@@ -12,9 +12,9 @@
 
 (use-fixtures :each
   (fn [test-fn]
-    (with-out-str
-      (test-fn)
-      (fs/delete-tree test-dir))))
+    #_(with-out-str)
+    (test-fn)
+    (fs/delete-tree test-dir)))
 
 (defn- tmp-dir [dir-name]
   (fs/file test-dir
@@ -376,6 +376,7 @@
           ;; Should rewrite everything when metadata modified
           (Thread/sleep 5)
           (write-test-post posts-dir {:title "Changed", :tags #{"not-clojure"}})
+          (println "Posts:" (map str (fs/glob posts-dir "**")))
           (Thread/sleep 500)
           (render)
           (doseq [[filename mtime] (merge content-cached metadata-cached)]

--- a/test/quickblog/api_test.clj
+++ b/test/quickblog/api_test.clj
@@ -585,6 +585,13 @@
                            (fs/create-dirs templates-dir)
                            (spit (fs/file templates-dir "base.html")
                                  "{{body | safe }}")
+                           (spit (fs/file templates-dir "index.html")
+                                 (str "{% for post in posts %}"
+                                      "{{post.title}}\n"
+                                      "{% if all forloop.last post.prev %}"
+                                      "prev: {{post.prev.title}}"
+                                      "{% endif %}"
+                                      "{% endfor %}"))
                            (spit (fs/file templates-dir "post.html")
                                  (str "{% if prev %}prev: {{prev.title}}{% endif %}"
                                       "\n"
@@ -602,7 +609,8 @@
                      :templates-dir templates-dir
                      :cache-dir cache-dir
                      :out-dir out-dir
-                     :link-prev-next-posts true})
+                     :link-prev-next-posts true
+                     :num-index-posts 2})
         (is (= (slurp (fs/file out-dir "post1.html"))
                "\nnext: post2"))
         (is (= (slurp (fs/file out-dir "post2.html"))
@@ -610,7 +618,9 @@
         (is (= (slurp (fs/file out-dir "post3.html"))
                "\n"))
         (is (= (slurp (fs/file out-dir "post4.html"))
-               "prev: post2\n"))))
+               "prev: post2\n"))
+        (is (= (slurp (fs/file out-dir "index.html"))
+               (str "post4\npost2\nprev: post1")))))
 
     (testing "include preview posts"
       (with-dirs [posts-dir

--- a/test/quickblog/api_test.clj
+++ b/test/quickblog/api_test.clj
@@ -313,7 +313,6 @@
         (Thread/sleep 5)
         (write-test-post posts-dir)
         (write-test-file assets-dir "asset.txt" "something")
-        (Thread/sleep 500)
         (render)
         (let [asset-file (fs/file out-dir "assets" "asset.txt")
               mtime (fs/last-modified-time asset-file)]
@@ -357,7 +356,6 @@
                                              (->mtimes (fs/file out-dir "tags")
                                                        ["clojure.html"]))]
           ;; Shouldn't rewrite anything when post unmodified
-          (Thread/sleep 500)
           (render)
           (doseq [[filename mtime] (merge content-cached clojure-metadata-cached)]
             (is (= (map str [filename mtime])
@@ -378,6 +376,17 @@
           (write-test-post posts-dir {:title "Changed", :tags #{"not-clojure"}})
           (println "Posts:" (map str (fs/glob posts-dir "**")))
           (Thread/sleep 500)
+          (write-test-post posts-dir)
+          (render)
+          (doseq [[filename mtime] content-cached]
+            (is (not= (map str [filename mtime])
+                      (map str [filename (fs/last-modified-time filename)]))))
+          (doseq [[filename mtime] clojure-metadata-cached]
+            (is (= (map str [filename mtime])
+                   (map str [filename (fs/last-modified-time filename)]))))
+          ;; Should rewrite everything when metadata modified
+          (Thread/sleep 500)
+          (write-test-post posts-dir {:title "Changed", :tags #{"not-clojure"}})
           (render)
           (doseq [[filename mtime] (merge content-cached metadata-cached)]
             (is (not= (map str [filename mtime])
@@ -435,7 +444,6 @@
                                     :tags #{"clojure"}})
         (write-test-post posts-dir {:file "random2.md"
                                     :tags #{"something"}})
-        (Thread/sleep 500)
         (let [mtimes (->mtimes out-dir ["atom.xml" "planetclojure.xml"])
               _ (render)
               mtimes-after (->mtimes out-dir ["atom.xml" "planetclojure.xml"])]
@@ -451,7 +459,6 @@
                  "clojure2.html"
                  "clojurescript1.html"}
                (post-ids (fs/file out-dir "planetclojure.xml"))))
-        (Thread/sleep 500)
         (let [mtimes (->mtimes out-dir ["atom.xml" "planetclojure.xml"])
               _ (render)
               mtimes-after (->mtimes out-dir ["atom.xml" "planetclojure.xml"])]

--- a/test/quickblog/api_test.clj
+++ b/test/quickblog/api_test.clj
@@ -12,9 +12,9 @@
 
 (use-fixtures :each
   (fn [test-fn]
-    #_(with-out-str)
-    (test-fn)
-    (fs/delete-tree test-dir)))
+    (with-out-str
+      (test-fn)
+      (fs/delete-tree test-dir))))
 
 (defn- tmp-dir [dir-name]
   (fs/file test-dir

--- a/test/quickblog/api_test.clj
+++ b/test/quickblog/api_test.clj
@@ -587,3 +587,64 @@
                     mtime (str (fs/last-modified-time file))]]
         (is (= [filename (mtimes filename)]
                [filename mtime]))))))
+
+(deftest link-prev-next-posts
+  (let [posts (->> (range 1 5)
+                   (map (fn [i]
+                          {:file (format "post%s.md" i)
+                           :title (format "post%s" i)
+                           :date (format "2024-02-0%s" i)
+                           :preview? (= 3 i)})))
+        write-templates! (fn [templates-dir]
+                           (fs/create-dirs templates-dir)
+                           (spit (fs/file templates-dir "base.html")
+                                 "{{body | safe }}")
+                           (spit (fs/file templates-dir "post.html")
+                                 (str "{% if prev %}prev: {{prev.title}}{% endif %}"
+                                      "\n"
+                                      "{% if next %}next: {{next.title}}{% endif %}")))]
+
+    (testing "add prev and next posts to post metadata"
+      (with-dirs [posts-dir
+                  templates-dir
+                  cache-dir
+                  out-dir]
+        (doseq [post posts]
+          (write-test-post posts-dir post))
+        (write-templates! templates-dir)
+        (api/render {:posts-dir posts-dir
+                     :templates-dir templates-dir
+                     :cache-dir cache-dir
+                     :out-dir out-dir
+                     :link-prev-next-posts true})
+        (is (= (slurp (fs/file out-dir "post1.html"))
+               "\nnext: post2"))
+        (is (= (slurp (fs/file out-dir "post2.html"))
+               "prev: post1\nnext: post4"))
+        (is (= (slurp (fs/file out-dir "post3.html"))
+               "\n"))
+        (is (= (slurp (fs/file out-dir "post4.html"))
+               "prev: post2\n"))))
+
+    (testing "include preview posts"
+      (with-dirs [posts-dir
+                  templates-dir
+                  cache-dir
+                  out-dir]
+        (doseq [post posts]
+          (write-test-post posts-dir post))
+        (write-templates! templates-dir)
+        (api/render {:posts-dir posts-dir
+                     :templates-dir templates-dir
+                     :cache-dir cache-dir
+                     :out-dir out-dir
+                     :link-prev-next-posts true
+                     :include-preview-posts-in-linking true})
+        (is (= (slurp (fs/file out-dir "post1.html"))
+               "\nnext: post2"))
+        (is (= (slurp (fs/file out-dir "post2.html"))
+               "prev: post1\nnext: post3"))
+        (is (= (slurp (fs/file out-dir "post3.html"))
+               "prev: post2\nnext: post4"))
+        (is (= (slurp (fs/file out-dir "post4.html"))
+               "prev: post3\n"))))))

--- a/test/quickblog/api_test.clj
+++ b/test/quickblog/api_test.clj
@@ -363,7 +363,6 @@
           ;; Should rewrite all but metadata-cached files when post modified
           (Thread/sleep 5)
           (write-test-post posts-dir)
-          (Thread/sleep 500)
           (render)
           (doseq [[filename mtime] content-cached]
             (is (not= (map str [filename mtime])
@@ -373,19 +372,6 @@
                    (map str [filename (fs/last-modified-time filename)]))))
           ;; Should rewrite everything when metadata modified
           (Thread/sleep 5)
-          (write-test-post posts-dir {:title "Changed", :tags #{"not-clojure"}})
-          (println "Posts:" (map str (fs/glob posts-dir "**")))
-          (Thread/sleep 500)
-          (write-test-post posts-dir)
-          (render)
-          (doseq [[filename mtime] content-cached]
-            (is (not= (map str [filename mtime])
-                      (map str [filename (fs/last-modified-time filename)]))))
-          (doseq [[filename mtime] clojure-metadata-cached]
-            (is (= (map str [filename mtime])
-                   (map str [filename (fs/last-modified-time filename)]))))
-          ;; Should rewrite everything when metadata modified
-          (Thread/sleep 500)
           (write-test-post posts-dir {:title "Changed", :tags #{"not-clojure"}})
           (render)
           (doseq [[filename mtime] (merge content-cached metadata-cached)]


### PR DESCRIPTION
If you set the `:link-prev-next-posts` option to `true`, quickblog adds `prev`
and `next` metadata to each post (where `prev` is the previous post and `next`
is the next post in date order, oldest to newest). You can make use of these by
adding something similar to this to your `post.html` template:

``` html
{% if any prev next %}
  <div class="post-prev-next">
{% if prev %}
    <div>⏪ <a href="{{prev.file|replace:.md:.html}}">{{prev.title}}</a></div>
{% endif %}
{% if next %}
    <div><a href="{{next.file|replace:.md:.html}}">{{next.title}}</a> ⏩</div>
{% endif %}
  </div>
{% endif %}
```

- [x] This PR corresponds to an [issue with a clear problem statement] #90 
- [x] I have updated the [CHANGELOG.md](https://github.com/babashka/babashka/blob/master/CHANGELOG.md) file with a description of the addressed issue.
