### PR TITLE
Fix version in quickstart example in README.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,9 @@ Instances of quickblog can be seen here:
 - Support Selmer template for new posts in api/new; see [Templates > New
   posts](README.md#new-posts) in README. ([@jmglov](https://github.com/jmglov))
 - Add 'language-xxx' to pre/code blocks
+- Fix README.md with working version in quickstart example
 
-## 0.3.6 (2031-12-31)
+## 0.3.6 (2023-12-31)
 
 - Fix caching (this is hard)
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ This example assumes a basic `bb.edn` like this:
 ``` clojure
 {:deps {io.github.borkdude/quickblog
         #_"You use the newest SHA here:"
-        {:git/sha "389833f393e04d4176ef3eaa5047fa307a5ff2e8"}}
+        {:git/sha "3a1d6aff07f692f6e62606317f3d9e981b1df702"}}
  :tasks
  {:requires ([quickblog.cli :as cli])
   :init (def opts {:blog-title "REPL adventures"
@@ -76,7 +76,7 @@ Default options can be configured in `:exec-args`.
 :quickblog
 {:deps {io.github.borkdude/quickblog
         #_"You use the newest SHA here:"
-        {:git/sha "389833f393e04d4176ef3eaa5047fa307a5ff2e8"}
+        {:git/sha "3a1d6aff07f692f6e62606317f3d9e981b1df702"}
         org.babashka/cli {:mvn/version "0.3.35"}}
  :main-opts ["-m" "babashka.cli.exec" "quickblog.cli" "run"]
  :exec-args {:blog-title "REPL adventures"


### PR DESCRIPTION
The sha to `quickblog` in the `bb.edn` example in README.md referenced a version that did not work out of the box, so this PR bumps the sha to the latest commit, which at the present moment works like expected.

Please answer the following questions and leave the below in as part of your PR.

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] I have updated the [CHANGELOG.md](https://github.com/babashka/babashka/blob/master/CHANGELOG.md) file with a description of the addressed issue.
