### PR TITLE
Fix: Expose :blog-image-alt option via CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Instances of quickblog can be seen [here](https://github.com/borkdude/quickblog?
 ## Unreleased
 
 - Add support for a blog contained within another website; see [Serving an alternate content root](README.md#serving-an-alternate-content-root) in README.  ([@jmglov](https://github.com/jmglov))
+- Fix `:blog-image-alt` option being ignored when using CLI (`bb quickblog render`)
 
 ## 0.4.7 (2025-06-12)
 

--- a/src/quickblog/api.clj
+++ b/src/quickblog/api.clj
@@ -142,6 +142,11 @@
       :ref "<url>"
       :group :social-sharing}
 
+     :blog-image-alt
+     {:desc "Alt text for blog thumbnail image"
+      :ref "<text>"
+      :group :social-sharing}
+
      ;; Favicon
      :favicon
      {:desc "If true, favicon will be added to all pages"


### PR DESCRIPTION
### Problem

The `:blog-image-alt` option works when calling `api/render` directly but is silently dropped when using the CLI (`bb quickblog render`).

**Example `bb.edn` configuration:**
```clojure
:init (def opts {:blog-title "My Blog"
                 :blog-image "assets/preview.png"
                 :blog-image-alt "My Blog preview image"})
```

| Method | Result |
|--------|--------|
| `(api/render opts)` | ✅ `blog-image-alt` works |
| `bb quickblog render` | ❌ `blog-image-alt` is ignored |

### Root Cause

`:blog-image-alt` is used throughout the codebase but was never added to the CLI spec:

- `api.clj` → `spit-index`, `spit-archive`, `spit-about`, tag generation
- `internal.clj` → `write-tag!`
- `api_test.clj` → tested at line 503

The CLI spec only included `:blog-image`:

```clojure
:blog-image
{:desc "Blog thumbnail image URL; see Features > Social sharing in README"
 :ref "<url>"
 :group :social-sharing}

;; :blog-image-alt was missing here
```

### Solution

Added `:blog-image-alt` to the CLI spec in the `:social-sharing` group:

```clojure
:blog-image-alt
{:desc "Alt text for blog thumbnail image"
 :ref "<text>"
 :group :social-sharing}
```

Now both options are passed through correctly when using `bb quickblog render`.

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] I have updated the [CHANGELOG.md](https://github.com/babashka/babashka/blob/master/CHANGELOG.md) file with a description of the addressed issue.
