### PR TITLE
fixed the example new-posts.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Instances of quickblog can be seen [here](https://github.com/borkdude/quickblog?
 
 ## Unreleased
 
+- Fixed new-post.md example in README.md
 - Upgrade babashka/http-server to 0.1.14
 - Add support for a blog contained within another website; see [Serving an alternate content root](https://github.com/borkdude/quickblog/README.md#serving-an-alternate-content-root) in README.  ([@jmglov](https://github.com/jmglov))
 - Fix `:blog-image-alt` option being ignored when using CLI (`bb quickblog render`)

--- a/README.md
+++ b/README.md
@@ -284,11 +284,11 @@ this:
 ``` markdown
 Title: {{title}}
 Date: {{date}}
-Tags: {{tags|join:\",\"}}
-Image: {% if image %}{{image}}{% else %}{{assets-dir}}/{{file|replace:.md:}}-preview.png{% endif %}
+Tags: {{tags|join:","}}
+Image: {% if image %}{{image}}{% else %}{{assets-dir}}/{{file|replace:".md":""}}-preview.png{% endif %}
 Image-Alt: {{image-alt|default:FIXME}}
 Discuss: {{discuss|default:FIXME}}
-{% if preview %}Preview: true\n{% endif %}
+{% if preview %}Preview: true{% endif %}
 Write a blog post here!
 ```
 


### PR DESCRIPTION
Fix for borkdude/quickblog#116 Running the new-posts.md example as written results in an error. Running the example md template with `bb quickblog new` results in a selmer.filters error.

Removed the escaped quotes and made sure there's two arguments to replace. Running the new post example no longer errors.

- [X] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [X] I have updated the [CHANGELOG.md](https://github.com/babashka/babashka/blob/master/CHANGELOG.md) file with a description of the addressed issue.
